### PR TITLE
Moar helpful CMake messages

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -269,8 +269,11 @@ elseif(METIS_ROOT AND PARMETIS_ROOT)
 #  include_directories(${PARMETIS_ROOT}/include)
 #  set(MANUAL_PARMETIS TRUE)
 elseif(BUILD_METIS)
+  if(NOT EXISTS "${CMAKE_SOURCE_DIR}/external/metis/CMakeLists.txt")
+    message(FATAL_ERROR
+      "${CMAKE_SOURCE_DIR}/external/metis is not correctly set up. If you are building from source, make sure all git submodules in the source directory are checked out, e.g. with\ncd ${CMAKE_SOURCE_DIR} && git pull --recurse-submodules")
+  endif()
   add_subdirectory(external/metis)
-
   set(METIS_ROOT ${PROJECT_SOURCE_DIR}/external/metis)
   include_directories(${METIS_ROOT}/include)
 
@@ -287,6 +290,10 @@ else()
 endif()
 
 if(BUILD_KISSFFT)
+  if(NOT EXISTS "${CMAKE_SOURCE_DIR}/external/kiss_fft/CMakeLists.txt")
+    message(FATAL_ERROR
+      "${CMAKE_SOURCE_DIR}/external/kiss_fft is not correctly set up. If you are building from source, make sure all git submodules in the source directory are checked out, e.g. with\ncd ${CMAKE_SOURCE_DIR} && git pull --recurse-submodules")
+  endif()
   add_subdirectory(external/kiss_fft)
   include_directories(external/kiss_fft)
 elseif(KISSFFT_INCLUDE_DIR AND KISSFFT_LIBS)
@@ -333,6 +340,10 @@ set(CXX_FLAGS "${CXX_FLAGS} ${EXTRA_FLAGS}")
 set(CMAKE_CXX_FLAGS_${UPPER_BUILD_TYPE} ${CXX_FLAGS})
 
 # Add the Parallel Multiple Relatively Robust Representations (PMRRR) project
+if(NOT EXISTS "${CMAKE_SOURCE_DIR}/external/pmrrr/CMakeLists.txt")
+   message(FATAL_ERROR
+      "${CMAKE_SOURCE_DIR}/external/pmrrr is not correctly set up. If you are building from source, make sure all git submodules in the source directory are checked out, e.g. with\ncd ${CMAKE_SOURCE_DIR} && git pull --recurse-submodules")
+endif()
 add_subdirectory(external/pmrrr)
 
 # Create the Elemental configuration header

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -198,8 +198,8 @@ endif()
 
 # Elemental must be built "out-of-source", so we start by ensuring that the
 # source and build directories are different.
-if("${PROJECT_SOURCE_DIR}" STREQUAL "${PROJECT_BINARY_DIR}")
-  message(FATAL_ERROR "In-source build attempted; please clean the CMake cache and then switch to an out-of-source build, e.g., rm CMakeCache.txt && rm -Rf CMakeFiles/ && mkdir build/ && cd build/ && cmake ..")
+if(PROJECT_SOURCE_DIR STREQUAL PROJECT_BINARY_DIR)
+  message(FATAL_ERROR "In-source build attempted; please clean the CMake cache and then switch to an out-of-source build, e.g.,\nrm CMakeCache.txt && rm -Rf CMakeFiles/\nmkdir build/ && cd build/ && cmake ..")
 endif()
 
 # Get the Git revision


### PR DESCRIPTION
- CMake prints errors if submodules are not checked out
- Test for in-source build prints the suggested commands on newlines so that
  users can copy-paste them