### PR TITLE
Create `make test` target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -388,6 +388,12 @@ configure_file(${PROJECT_SOURCE_DIR}/cmake/ElVars.cmake
                ${PROJECT_BINARY_DIR}/conf/ElVars @ONLY)
 install(FILES ${PROJECT_BINARY_DIR}/conf/ElVars DESTINATION conf)
 
+#Install sandbox test
+configure_file(${PROJECT_SOURCE_DIR}/sandbox/Makefile
+		${PROJECT_BINARY_DIR}/sandbox/Makefile @ONLY)
+install(FILES ${PROJECT_BINARY_DIR}/sandbox/Makefile DESTINATION sandbox)
+install(FILES ${PROJECT_SOURCE_DIR}/sandbox/test.cpp DESTINATION sandbox)
+
 # The main library
 # ================
 
@@ -560,3 +566,9 @@ endif()
 if(NOT CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
   include(./cmake/ElSub.cmake)
 endif()
+
+# Add sandbox/test program
+include(CTest)
+
+add_test(NAME sandbox_test WORKING_DIRECTORY ${CMAKE_INSTALL_PREFIX}/sandbox COMMAND make)
+

--- a/sandbox/Makefile
+++ b/sandbox/Makefile
@@ -1,6 +1,13 @@
-include /usr/conf/ElVars
+include @CMAKE_INSTALL_PREFIX@/conf/ElVars
+
+OS := $(shell uname)
+
+all: test
+	if [ x$(OS) == xLinux ]; then LD_LIBRARY_PATH=$(LD_LIBRARY_PATH):$(EL_LIB) ./test; fi
+	if [ x$(OS) == xDarwin ]; then DYLD_LIBRARY_PATH=$(DYLD_LIBRARY_PATH):$(EL_LIB) ./test; fi
 
 test: test.cpp
 	$(CXX) $(EL_COMPILE_FLAGS) $< -o $@ $(EL_LINK_FLAGS) $(EL_LIBS)
+
 clean:
 	rm test


### PR DESCRIPTION
Tests!!

Uses CTest to create a sandbox_test test target, which runs the sandbox test to see if it builds and runs.

Installs the contents of sandbox and sets the necessary environment variables so that the tests will run