### PR TITLE
Travis now only generates code coverage for gcc

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,21 +32,31 @@ install:
   - gem install coveralls-lcov
 
 before_script:
-  - if test x$CC = xclang; then export CC=clang-3.7; export CXX=clang++-3.7; fi
-  - if test x$CC = xgcc; then export CC=gcc-4.9; export CXX=g++-4.9; fi
+  - if test x$CC = xclang; then;
+      export CC=clang-3.7;
+      export CXX=clang++-3.7;
+      export FLAGS="-O3 -Wall -Wl,--no-keep-memory";
+    fi
+  - if test x$CC = xgcc; then;
+      export CC=gcc-4.9;
+      export CXX=g++-4.9;
+      export FLAGS="-g -Os -Wall -fprofile-arcs -ftest-coverage";
+    fi
   - sudo hostname localhost
   - test $MPI == mpich2 && MPIEXEC='mpiexec -launcher fork' || true
   - lcov --directory . --zerocounters
 
 script:
   - mkdir build && cd build;
-    cmake .. -DASSERT=ON -DASSERT2=ON -DEL_TESTS=ON -DEL_EXAMPLES=ON -DCXX_FLAGS="-g -Os -Wall -fprofile-arcs -ftest-coverage -Wl,--no-keep-memory" -DC_FLAGS="-g -Os -Wall -fprofile-arcs -ftest-coverage -Wl,--no-keep-memory" -DFortran_FLAGS="-g -Os -Wall -fprofile-arcs -ftest-coverage -Wl,--no-keep-memory" -DCMAKE_BUILD_TYPE=Release;
+  - cmake .. -DASSERT=ON -DASSERT2=ON -DEL_TESTS=ON -DEL_EXAMPLES=ON -DCXX_FLAGS="$FLAGS" -DC_FLAGS="$FLAGS" -DFortran_FLAGS="$FLAGS" -DCMAKE_BUILD_TYPE=Release;
     if test $? -ne 0; then cat CMakeFiles/CMakeError.log; fi
   - make -j3 && sudo make -j2 install && sudo ctest -j3 --output-on-failure
 
 after_success:
-  - lcov --directory . --capture --output-file coverage.info # capture coverage info
-  - lcov --remove coverage.info 'tests/*' '/usr/*' --output-file coverage.info # filter out system and test code
-  - lcov --list coverage.info # debug before upload
-  - coveralls-lcov --repo-token orrZO32nywoXo9Y70QEcCJ3M8v00QVOaC coverage.info # uploads to coveralls
+  - if test x$CC = xgcc-4.9; then;
+       lcov --directory . --capture --output-file coverage.info;
+       lcov --remove coverage.info 'tests/*' '/usr/*' --output-file coverage.info;
+       lcov --list coverage.info;
+       coveralls-lcov --repo-token orrZO32nywoXo9Y70QEcCJ3M8v00QVOaC coverage.info;
+    fi
 


### PR DESCRIPTION
Hopefully minimizes clang timeouts