### PR TITLE
Updated toolchain files for BG/Q, Mira.

### DIFF
--- a/cmake/toolchains/BGQ-Mira-clang-essl.cmake
+++ b/cmake/toolchains/BGQ-Mira-clang-essl.cmake
@@ -1,9 +1,11 @@
-#set(CMAKE_SYSTEM_NAME BlueGeneQ-static)
+# Set the system name so CMake uses the appropriate platform settings.
+# NOTE: The platforms settings for BlueGeneP are the same for BlueGeneQ 
+set(CMAKE_SYSTEM_NAME BlueGeneP-static)
 
-set(GCC_ROOT  "/bgsys/drivers/ppcfloor/gnu-linux")
+set(GCC_ROOT  "/bgsys/drivers/ppcfloor/gnu-linux-4.7.2")
 set(GCC_NAME  "powerpc64-bgq-linux")
-set(CLANG_ROOT "/home/projects/llvm")
-set(CLANG_MPI_ROOT "/home/projects/llvm/mpi/bgclang")
+set(CLANG_ROOT "/soft/compilers/bgclang")
+set(CLANG_MPI_ROOT "${CLANG_ROOT}/mpi/bgclang")
 set(IBMCMP_ROOT "$ENV{IBM_MAIN_DIR}")
 
 set(BLAS_LIB "/soft/libraries/alcf/current/xl/BLAS/lib")
@@ -20,16 +22,8 @@ set(CMAKE_CXX_COMPILER     "${CLANG_ROOT}/wbin/bgclang++11")
 set(CMAKE_Fortran_COMPILER "${GCC_ROOT}/bin/${GCC_NAME}-gfortran")
 
 # The MPI wrappers for the C and C++ compilers
-set(MPI_C_COMPILER   "${CLANG_MPI_ROOT}/bin/mpiclang")
-set(MPI_CXX_COMPILER "${CLANG_MPI_ROOT}/bin/mpiclang++11")
-
-set(MPI_C_COMPILE_FLAGS    "")
-set(MPI_CXX_COMPILE_FLAGS  "")
-set(MPI_C_INCLUDE_PATH     "${MPI_ROOT}/include")
-set(MPI_CXX_INCLUDE_PATH   "${MPI_ROOT}/include")
-set(MPI_LINK_FLAGS       "-L${MPI_ROOT}/lib -L${PAMI_ROOT}/lib -L${SPI_ROOT}/lib")
-set(MPI_C_LIBRARIES       "${MPI_LINK_FLAGS}   -lmpich -lopa -lmpl -lpami -lSPI -lSPI_cnk -lrt -lpthread -lstdc++ -lpthread")
-set(MPI_CXX_LIBRARIES     "${MPI_LINK_FLAGS} -lcxxmpich ${MPI_C_LIBRARIES}")
+set(MPI_C_COMPILER   "${CLANG_MPI_ROOT}/bin/mpicc")
+set(MPI_CXX_COMPILER "${CLANG_MPI_ROOT}/bin/mpic++11")
 
 if(CMAKE_BUILD_TYPE MATCHES Debug)
   set(CXX_FLAGS "-g")
@@ -39,27 +33,6 @@ endif()
 
 set(CMAKE_THREAD_LIBS_INIT "-fopenmp")
 set(OpenMP_CXX_FLAGS "-fopenmp")
-
-##############################################################
-
-# set the search path for the environment coming with the compiler
-# and a directory where you can install your own compiled software
-set(CMAKE_FIND_ROOT_PATH
-    /bgsys/drivers/ppcfloor
-    /bgsys/drivers/ppcfloor/gnu-linux/powerpc64-bgq-linux
-    /bgsys/drivers/ppcfloor/comm/xl
-    /bgsys/drivers/ppcfloor/comm/sys
-    /bgsys/drivers/ppcfloor/spi
-)
-
-# adjust the default behaviour of the FIND_XXX() commands:
-# search headers and libraries in the target environment, search
-# programs in the host environment
-set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
-set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
-set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
-
-##############################################################
 
 set(XLF_LIB "${IBMCMP_ROOT}/xlf/bg/14.1/bglib64")
 set(XLSMP_LIB "${IBMCMP_ROOT}/xlsmp/bg/3.1/bglib64")

--- a/cmake/toolchains/BGQ-Mira-gnu-essl.cmake
+++ b/cmake/toolchains/BGQ-Mira-gnu-essl.cmake
@@ -1,0 +1,49 @@
+# Set the system name so CMake uses the appropriate platform settings.
+# NOTE: The platforms settings for BlueGeneP are the same for BlueGeneQ 
+set(CMAKE_SYSTEM_NAME BlueGeneP-static)
+
+# The serial compilers are typically set here, but, at least at some point,
+# it was easier to set them to the MPI compilers.
+set(GCC_DIR    "/bgsys/drivers/ppcfloor/gnu-linux-4.7.2")
+set(MPI_DIR    "/bgsys/drivers/ppcfloor/comm/gcc")
+
+set(CMAKE_C_COMPILER       ${GCC_DIR}/bin/powerpc64-bgq-linux-gcc)
+set(CMAKE_CXX_COMPILER     ${GCC_DIR}/bin/powerpc64-bgq-linux-g++)
+set(CMAKE_Fortran_COMPILER ${GCC_DIR}/bin/powerpc64-bgq-linux-gfortran)
+
+# The MPI wrappers for the C and C++ compilers
+set(MPI_C_COMPILER   ${MPI_DIR}/bin/mpicc)
+set(MPI_CXX_COMPILER ${MPI_DIR}/bin/mpicxx)
+
+set(PAMI_ROOT "/bgsys/drivers/ppcfloor/comm/sys")
+set(SPI_ROOT  "/bgsys/drivers/ppcfloor/spi")
+
+if(CMAKE_BUILD_TYPE MATCHES Debug)
+  set(CXX_FLAGS "-g")
+else()
+  set(CXX_FLAGS "-g -O3")
+endif()
+
+set(CMAKE_THREAD_LIBS_INIT "-fopenmp")
+set(OpenMP_CXX_FLAGS "-fopenmp")
+
+set(LAPACK_LIB "/soft/libraries/alcf/current/gcc/LAPACK/lib")
+set(ESSL_LIB "/soft/libraries/essl/current/essl/5.1/lib64")
+set(IBMCMP_ROOT "/soft/compilers/ibmcmp-nov2012")
+set(XLF_LIB "${IBMCMP_ROOT}/xlf/bg/14.1/bglib64")
+set(XLSMP_LIB "${IBMCMP_ROOT}/xlsmp/bg/3.1/bglib64")
+
+set(LAPACK_FLAGS "-L${LAPACK_LIB} -llapack")
+set(XLF_FLAGS "-L${XLF_LIB} -lxlf90_r")
+
+if(EL_HYBRID)
+  set(ESSL_FLAGS "-L${ESSL_LIB} -lesslsmpbg") 
+  set(XL_FLAGS "-L${XLSMP_LIB} -lxlsmp")
+else()
+  set(ESSL_FLAGS "-L${ESSL_LIB} -lesslbg")
+  set(XL_FLAGS "-L${XLSMP_LIB} -lxlomp_ser")
+endif()
+
+#set(CMAKE_FIND_LIBRARY_SUFFIXES .a ${CMAKE_FIND_LIBRARY_SUFFIXES})
+#set(CMAKE_EXE_LINKER_FLAGS "-static")
+set(MATH_LIBS "-L/soft/libraries/alcf/current/gcc/SCALAPACK/lib -lscalapack ${LAPACK_FLAGS} ${ESSL_FLAGS} ${XLF_FLAGS} ${XL_FLAGS} -lxlopt -lxlfmath -lxl -lgfortran -lm -lpthread -ldl -Wl,--allow-multiple-definition")


### PR DESCRIPTION
- Corrected paths and variables for BGQ-Mira-clang-essl.cmake toolchain.
- Added BGQ-Mira-gnu-essl.cmake toolchain file.
- Set the platform name in the above toolchain files to BlueGeneP-static, which also works for BG/Q.