### PR TITLE
BigInt and a BigFloat fix

### DIFF
--- a/include/El/blas_like.hpp
+++ b/include/El/blas_like.hpp
@@ -29,10 +29,12 @@ template<> void SetLocalSymvBlocksize<Quad>( Int blocksize );
 template<> void SetLocalSymvBlocksize<Complex<Quad>>( Int blocksize );
 #endif
 #ifdef EL_HAVE_MPC
+template<> void SetLocalSymvBlocksize<BigInt>( Int blocksize );
 template<> void SetLocalSymvBlocksize<BigFloat>( Int blocksize );
 #endif
 
 template<typename T> void SetLocalTrrkBlocksize( Int blocksize );
+template<> void SetLocalTrrkBlocksize<Int>( Int blocksize );
 template<> void SetLocalTrrkBlocksize<float>( Int blocksize );
 template<> void SetLocalTrrkBlocksize<double>( Int blocksize );
 template<> void SetLocalTrrkBlocksize<Complex<float>>( Int blocksize );
@@ -46,10 +48,12 @@ template<> void SetLocalTrrkBlocksize<Quad>( Int blocksize );
 template<> void SetLocalTrrkBlocksize<Complex<Quad>>( Int blocksize );
 #endif
 #ifdef EL_HAVE_MPC
+template<> void SetLocalTrrkBlocksize<BigInt>( Int blocksize );
 template<> void SetLocalTrrkBlocksize<BigFloat>( Int blocksize );
 #endif
 
 template<typename T> void SetLocalTrr2kBlocksize( Int blocksize );
+template<> void SetLocalTrr2kBlocksize<Int>( Int blocksize );
 template<> void SetLocalTrr2kBlocksize<float>( Int blocksize );
 template<> void SetLocalTrr2kBlocksize<double>( Int blocksize );
 template<> void SetLocalTrr2kBlocksize<Complex<float>>( Int blocksize );
@@ -63,10 +67,12 @@ template<> void SetLocalTrr2kBlocksize<Quad>( Int blocksize );
 template<> void SetLocalTrr2kBlocksize<Complex<Quad>>( Int blocksize );
 #endif
 #ifdef EL_HAVE_MPC
+template<> void SetLocalTrr2kBlocksize<BigInt>( Int blocksize );
 template<> void SetLocalTrr2kBlocksize<BigFloat>( Int blocksize );
 #endif
 
 template<typename T> Int LocalSymvBlocksize();
+template<> Int LocalSymvBlocksize<Int>();
 template<> Int LocalSymvBlocksize<float>();
 template<> Int LocalSymvBlocksize<double>();
 template<> Int LocalSymvBlocksize<Complex<float>>();
@@ -80,10 +86,12 @@ template<> Int LocalSymvBlocksize<Quad>();
 template<> Int LocalSymvBlocksize<Complex<Quad>>();
 #endif
 #ifdef EL_HAVE_MPC
+template<> Int LocalSymvBlocksize<BigInt>();
 template<> Int LocalSymvBlocksize<BigFloat>();
 #endif
 
 template<typename T> Int LocalTrrkBlocksize();
+template<> Int LocalTrrkBlocksize<Int>();
 template<> Int LocalTrrkBlocksize<float>();
 template<> Int LocalTrrkBlocksize<double>();
 template<> Int LocalTrrkBlocksize<Complex<float>>();
@@ -97,10 +105,12 @@ template<> Int LocalTrrkBlocksize<Quad>();
 template<> Int LocalTrrkBlocksize<Complex<Quad>>();
 #endif
 #ifdef EL_HAVE_MPC
+template<> Int LocalTrrkBlocksize<BigInt>();
 template<> Int LocalTrrkBlocksize<BigFloat>();
 #endif
 
 template<typename T> Int LocalTrr2kBlocksize();
+template<> Int LocalTrr2kBlocksize<Int>();
 template<> Int LocalTrr2kBlocksize<float>();
 template<> Int LocalTrr2kBlocksize<double>();
 template<> Int LocalTrr2kBlocksize<Complex<float>>();
@@ -114,6 +124,7 @@ template<> Int LocalTrr2kBlocksize<Quad>();
 template<> Int LocalTrr2kBlocksize<Complex<Quad>>();
 #endif
 #ifdef EL_HAVE_MPC
+template<> Int LocalTrr2kBlocksize<BigInt>();
 template<> Int LocalTrr2kBlocksize<BigFloat>();
 #endif
 

--- a/include/El/blas_like/level1.hpp
+++ b/include/El/blas_like/level1.hpp
@@ -1579,6 +1579,12 @@ void RotateCols( Base<F> c, F s, AbstractDistMatrix<F>& A, Int j1, Int j2 );
 // Round each entry to the nearest integer
 template<typename T>
 void Round( Matrix<T>& A );
+template<>
+void Round( Matrix<Int>& A );
+#ifdef EL_HAVE_MPC
+template<>
+void Round( Matrix<BigInt>& A );
+#endif
 template<typename T>
 void Round( AbstractDistMatrix<T>& A );
 template<typename T>

--- a/include/El/core/Element/decl.hpp
+++ b/include/El/core/Element/decl.hpp
@@ -79,7 +79,11 @@ using DisableIf = typename std::enable_if<!Condition::value,T>::type;
 // Types that Matrix, DistMatrix, etc. are instantiatable with
 // -----------------------------------------------------------
 template<typename T>
-using IsIntegral = std::is_integral<T>;
+struct IsIntegral { static const bool value = std::is_integral<T>::value; };
+#ifdef EL_HAVE_MPC
+template<>
+struct IsIntegral<BigInt> { static const bool value = true; };
+#endif
 
 template<typename T> struct IsScalar { static const bool value=false; };
 template<> struct IsScalar<Int> { static const bool value=true; };
@@ -96,6 +100,7 @@ template<> struct IsScalar<Quad> { static const bool value=true; };
 template<> struct IsScalar<Complex<Quad>> { static const bool value=true; };
 #endif
 #ifdef EL_HAVE_MPC
+template<> struct IsScalar<BigInt> { static const bool value=true; };
 template<> struct IsScalar<BigFloat> { static const bool value=true; };
 #endif
 
@@ -279,6 +284,7 @@ template<> struct IsData<Quad> { static const bool value=true; };
 template<> struct IsData<Complex<Quad>> { static const bool value=true; };
 #endif
 #ifdef EL_HAVE_MPC
+template<> struct IsData<BigInt> { static const bool value=true; };
 template<> struct IsData<BigFloat> { static const bool value=true; };
 #endif
 
@@ -383,6 +389,7 @@ template<> Quad Abs( const Quad& alpha ) EL_NO_EXCEPT;
 template<> Quad Abs( const Complex<Quad>& alpha ) EL_NO_EXCEPT;
 #endif
 #ifdef EL_HAVE_MPC
+template<> BigInt Abs( const BigInt& alpha ) EL_NO_EXCEPT;
 template<> BigFloat Abs( const BigFloat& alpha ) EL_NO_EXCEPT;
 #endif
 
@@ -409,6 +416,8 @@ Real FastAbs( const Complex<Real>& alpha ) EL_NO_EXCEPT;
 template<typename Real,typename=EnableIf<IsReal<Real>>>
 Real Sgn( const Real& alpha, bool symmetric=true ) EL_NO_EXCEPT;
 #ifdef EL_HAVE_MPC
+// TODO: Continue adding BigInt support
+BigInt Sgn( const BigInt& alpha, bool symmetric=true ) EL_NO_EXCEPT;
 BigFloat Sgn( const BigFloat& alpha, bool symmetric=true ) EL_NO_EXCEPT;
 #endif
 
@@ -431,30 +440,31 @@ template<> BigFloat Exp( const BigFloat& alpha ) EL_NO_EXCEPT;
 template<typename F,typename T,
          typename=EnableIf<IsScalar<F>>,
          typename=EnableIf<IsScalar<T>>>
-F Pow( const F& alpha, const T& beta ) EL_NO_EXCEPT;
+F Pow( const F& alpha, const T& beta );
 #ifdef EL_USE_64BIT_INTS
 template<typename F,typename=EnableIf<IsScalar<F>>>
-F Pow( const F& alpha, const int& beta ) EL_NO_EXCEPT;
+F Pow( const F& alpha, const int& beta );
 #endif
 #ifdef EL_HAVE_QD
 template<>
-DoubleDouble Pow
-( const DoubleDouble& alpha, const DoubleDouble& beta ) EL_NO_EXCEPT;
+DoubleDouble Pow( const DoubleDouble& alpha, const DoubleDouble& beta );
 template<>
-QuadDouble Pow
-( const QuadDouble& alpha, const QuadDouble& beta ) EL_NO_EXCEPT;
+QuadDouble Pow( const QuadDouble& alpha, const QuadDouble& beta );
 #endif
 #ifdef EL_HAVE_QUAD
-template<> Quad Pow( const Quad& alpha, const Quad& beta ) EL_NO_EXCEPT;
+template<> Quad Pow( const Quad& alpha, const Quad& beta );
 template<>
-Complex<Quad> Pow
-( const Complex<Quad>& alpha, const Complex<Quad>& beta ) EL_NO_EXCEPT;
+Complex<Quad> Pow( const Complex<Quad>& alpha, const Complex<Quad>& beta );
 template<>
-Complex<Quad> Pow( const Complex<Quad>& alpha, const Quad& beta ) EL_NO_EXCEPT;
+Complex<Quad> Pow( const Complex<Quad>& alpha, const Quad& beta );
 #endif
 #ifdef EL_HAVE_MPC
 template<>
-BigFloat Pow( const BigFloat& alpha, const BigFloat& beta ) EL_NO_EXCEPT;
+BigFloat Pow( const BigFloat& alpha, const BigFloat& beta );
+template<>
+BigInt Pow( const BigInt& alpha, const BigInt& beta );
+BigInt Pow( const BigInt& alpha, const unsigned& beta );
+BigInt Pow( const BigInt& alpha, const unsigned long& beta );
 #endif
 
 template<typename F,typename=EnableIf<IsScalar<F>>>
@@ -697,6 +707,7 @@ template<> QuadDouble Round( const QuadDouble& alpha );
 template<> Quad Round( const Quad& alpha );
 #endif
 #ifdef EL_HAVE_MPC
+template<> BigInt Round( const BigInt& alpha );
 template<> BigFloat Round( const BigFloat& alpha );
 #endif
 
@@ -718,6 +729,7 @@ template<> QuadDouble Ceil( const QuadDouble& alpha );
 template<> Quad Ceil( const Quad& alpha );
 #endif
 #ifdef EL_HAVE_MPC
+template<> BigInt Ceil( const BigInt& alpha );
 template<> BigFloat Ceil( const BigFloat& alpha );
 #endif
 
@@ -739,6 +751,7 @@ template<> QuadDouble Floor( const QuadDouble& alpha );
 template<> Quad Floor( const Quad& alpha );
 #endif
 #ifdef EL_HAVE_MPC
+template<> BigInt Floor( const BigInt& alpha );
 template<> BigFloat Floor( const BigFloat& alpha );
 #endif
 

--- a/include/El/core/Element/impl.hpp
+++ b/include/El/core/Element/impl.hpp
@@ -178,12 +178,12 @@ template<typename F,typename>
 F Exp( const F& alpha ) EL_NO_EXCEPT { return std::exp(alpha); }
 
 template<typename F,typename T,typename,typename>
-F Pow( const F& alpha, const T& beta ) EL_NO_EXCEPT
+F Pow( const F& alpha, const T& beta )
 { return std::pow(alpha,beta); }
 
 #ifdef EL_USE_64BIT_INTS
 template<typename F,typename>
-F Pow( const F& alpha, const int& beta ) EL_NO_EXCEPT
+F Pow( const F& alpha, const int& beta )
 { return Pow(alpha,F(beta)); }
 #endif
 

--- a/include/El/core/Serialize.hpp
+++ b/include/El/core/Serialize.hpp
@@ -14,19 +14,38 @@ namespace El {
 
 #ifdef EL_HAVE_MPC
 
+byte* Serialize( Int n, const BigInt* x, byte* xPacked );
+byte* Serialize( Int n, const ValueInt<BigInt>* x, byte* xPacked );
+byte* Serialize( Int n, const Entry<BigInt>* x, byte* xPacked );
+
 byte* Serialize( Int n, const BigFloat* x, byte* xPacked );
 byte* Serialize( Int n, const ValueInt<BigFloat>* x, byte* xPacked );
 byte* Serialize( Int n, const Entry<BigFloat>* x, byte* xPacked );
 
+byte* Deserialize( Int n, byte* xPacked, BigInt* x );
+byte* Deserialize( Int n, byte* xPacked, ValueInt<BigInt>* x );
+byte* Deserialize( Int n, byte* xPacked, Entry<BigInt>* x );
+
 byte* Deserialize( Int n, byte* xPacked, BigFloat* x );
 byte* Deserialize( Int n, byte* xPacked, ValueInt<BigFloat>* x );
 byte* Deserialize( Int n, byte* xPacked, Entry<BigFloat>* x );
+
+const byte* Deserialize( Int n, const byte* xPacked, BigInt* x );
+const byte* Deserialize( Int n, const byte* xPacked, ValueInt<BigInt>* x );
+const byte* Deserialize( Int n, const byte* xPacked, Entry<BigInt>* x );
 
 const byte* Deserialize( Int n, const byte* xPacked, BigFloat* x );
 const byte* Deserialize( Int n, const byte* xPacked, ValueInt<BigFloat>* x );
 const byte* Deserialize( Int n, const byte* xPacked, Entry<BigFloat>* x );
 
 void ReserveSerialized
+( Int n, const BigInt* x, std::vector<byte>& xPacked );
+void ReserveSerialized
+( Int n, const ValueInt<BigInt>* x, std::vector<byte>& xPacked );
+void ReserveSerialized
+( Int n, const Entry<BigInt>* x, std::vector<byte>& xPacked );
+
+void ReserveSerialized
 ( Int n, const BigFloat* x, std::vector<byte>& xPacked );
 void ReserveSerialized
 ( Int n, const ValueInt<BigFloat>* x, std::vector<byte>& xPacked );
@@ -34,11 +53,25 @@ void ReserveSerialized
 ( Int n, const Entry<BigFloat>* x, std::vector<byte>& xPacked );
 
 void Serialize
+( Int n, const BigInt* x, std::vector<byte>& xPacked );
+void Serialize
+( Int n, const ValueInt<BigInt>* x, std::vector<byte>& xPacked );
+void Serialize
+( Int n, const Entry<BigInt>* x, std::vector<byte>& xPacked );
+
+void Serialize
 ( Int n, const BigFloat* x, std::vector<byte>& xPacked );
 void Serialize
 ( Int n, const ValueInt<BigFloat>* x, std::vector<byte>& xPacked );
 void Serialize
 ( Int n, const Entry<BigFloat>* x, std::vector<byte>& xPacked );
+
+void Deserialize
+( Int n, const std::vector<byte>& xPacked, BigInt* x );
+void Deserialize
+( Int n, const std::vector<byte>& xPacked, ValueInt<BigInt>* x );
+void Deserialize
+( Int n, const std::vector<byte>& xPacked, Entry<BigInt>* x );
 
 void Deserialize
 ( Int n, const std::vector<byte>& xPacked, BigFloat* x );

--- a/include/El/core/environment/decl.hpp
+++ b/include/El/core/environment/decl.hpp
@@ -177,6 +177,13 @@ inline void FastResize( vector<T>& v, Int numEntries )
 #endif
 }
 #ifdef EL_HAVE_MPC
+inline void FastResize( vector<BigInt>& v, Int numEntries )
+{ v.resize( numEntries ); }
+inline void FastResize( vector<ValueInt<BigInt>>& v, Int numEntries )
+{ v.resize( numEntries ); }
+inline void FastResize( vector<Entry<BigInt>>& v, Int numEntries )
+{ v.resize( numEntries ); }
+
 inline void FastResize( vector<BigFloat>& v, Int numEntries )
 { v.resize( numEntries ); }
 inline void FastResize( vector<ValueInt<BigFloat>>& v, Int numEntries )

--- a/include/El/core/environment/decl.hpp
+++ b/include/El/core/environment/decl.hpp
@@ -118,12 +118,14 @@ inline const Int& Min( const Int& m, const Int& n ) EL_NO_EXCEPT
 template<typename T>
 void MemCopy( T* dest, const T* source, size_t numEntries );
 #ifdef EL_HAVE_MPC
+void MemCopy( BigInt* dest, const BigInt* source, size_t numEntries );
 void MemCopy( BigFloat* dest, const BigFloat* source, size_t numEntries );
 #endif
 
 template<typename T>
 void MemSwap( T* a, T* b, T* temp, size_t numEntries );
 #ifdef EL_HAVE_MPC
+void MemSwap( BigInt* a, BigInt* b, BigInt* temp, size_t numEntries );
 void MemSwap( BigFloat* a, BigFloat* b, BigFloat* temp, size_t numEntries );
 #endif
 
@@ -133,6 +135,9 @@ void StridedMemCopy
 (       T* dest,   Int destStride,
   const T* source, Int sourceStride, Int numEntries );
 #ifdef EL_HAVE_MPC
+void StridedMemCopy
+(       BigInt* dest,   Int destStride,
+  const BigInt* source, Int sourceStride, Int numEntries );
 void StridedMemCopy
 (       BigFloat* dest,   Int destStride,
   const BigFloat* source, Int sourceStride, Int numEntries );
@@ -150,6 +155,7 @@ inline void CopySTL( const S& a, T& b )
 template<typename T>
 void MemZero( T* buffer, size_t numEntries );
 #ifdef EL_HAVE_MPC
+void MemZero( BigInt* buffer, size_t numEntries );
 void MemZero( BigFloat* buffer, size_t numEntries );
 #endif
 

--- a/include/El/core/environment/impl.hpp
+++ b/include/El/core/environment/impl.hpp
@@ -39,6 +39,13 @@ MemCopy( T* dest, const T* source, size_t numEntries )
 }
 #ifdef EL_HAVE_MPC
 inline void
+MemCopy( BigInt* dest, const BigInt* source, size_t numEntries )
+{
+    for( size_t k=0; k<numEntries; ++k )
+        dest[k] = source[k];
+}
+
+inline void
 MemCopy( BigFloat* dest, const BigFloat* source, size_t numEntries )
 {
     for( size_t k=0; k<numEntries; ++k )
@@ -58,6 +65,19 @@ MemSwap( T* a, T* b, T* temp, size_t numEntries )
     MemCopy( b, temp, numEntries );
 }
 #ifdef EL_HAVE_MPC
+inline void
+MemSwap( BigInt* a, BigInt* b, BigInt* temp, size_t numEntries )
+{
+    // NOTE: This is the same as above for now
+
+    // temp := a
+    MemCopy( temp, a, numEntries );
+    // a := b
+    MemCopy( a, b, numEntries );
+    // b := temp
+    MemCopy( b, temp, numEntries );
+}
+
 inline void
 MemSwap( BigFloat* a, BigFloat* b, BigFloat* temp, size_t numEntries )
 {
@@ -84,6 +104,15 @@ StridedMemCopy
 #ifdef EL_HAVE_MPC
 inline void
 StridedMemCopy
+(       BigInt* dest,   Int destStride,
+  const BigInt* source, Int sourceStride, Int numEntries )
+{
+    for( Int k=0; k<numEntries; ++k )
+        dest[destStride*k] = source[sourceStride*k];
+}
+
+inline void
+StridedMemCopy
 (       BigFloat* dest,   Int destStride,
   const BigFloat* source, Int sourceStride, Int numEntries )
 {
@@ -100,6 +129,12 @@ MemZero( T* buffer, size_t numEntries )
     std::memset( buffer, 0, numEntries*sizeof(T) );
 }
 #ifdef EL_HAVE_MPC
+inline void MemZero( BigInt* buffer, size_t numEntries )
+{
+    for( size_t k=0; k<numEntries; ++k )
+        buffer[k].Zero();
+}
+
 inline void MemZero( BigFloat* buffer, size_t numEntries )
 {
     for( size_t k=0; k<numEntries; ++k )

--- a/include/El/core/imports/mpc.hpp
+++ b/include/El/core/imports/mpc.hpp
@@ -28,6 +28,10 @@ mpfr_prec_t Precision();
 size_t NumLimbs();
 void SetPrecision( mpfr_prec_t precision );
 
+int NumIntBits();
+int NumIntLimbs();
+void SetMinIntBits( int minIntBits );
+
 Int BinaryToDecimalPrecision( mpfr_prec_t precision );
 
 // NOTE: These should only be called internally
@@ -37,6 +41,192 @@ void FreeMPI();
 mpfr_rnd_t RoundingMode();
 
 } // namespace mpc
+
+class BigInt {
+private:
+    mpz_t mpzInt_;
+
+public:
+    mpz_ptr Pointer();
+    mpz_srcptr LockedPointer() const;
+    void SetNumLimbs( int numLimbs );
+    void SetMinBits( int minBits );
+    int NumLimbs() const;
+    int NumBits() const;
+
+    BigInt();
+    BigInt( const BigInt& a, int numBits=mpc::NumIntBits() );
+    BigInt( const unsigned& a, int numBits=mpc::NumIntBits() );
+    BigInt( const unsigned long& a, int numBits=mpc::NumIntBits() );
+    BigInt( const unsigned long long& a, int numBits=mpc::NumIntBits() );
+    BigInt( const int& a, int numBits=mpc::NumIntBits() );
+    BigInt( const long int& a, int numBits=mpc::NumIntBits() );
+    BigInt( const long long int& a, int numBits=mpc::NumIntBits() );
+    BigInt( const double& a, int numBits=mpc::NumIntBits() );
+    BigInt( const char* str, int base, int numBits=mpc::NumIntBits() );
+    BigInt( const std::string& str, int base, int numBits=mpc::NumIntBits() );
+    BigInt( BigInt&& a );
+    ~BigInt();
+
+    void Zero();
+
+    BigInt& operator=( const BigInt& a );
+    BigInt& operator=( const unsigned& a );
+    BigInt& operator=( const unsigned long& a );
+    BigInt& operator=( const unsigned long long& a );
+    BigInt& operator=( const int& a );
+    BigInt& operator=( const long int& a );
+    BigInt& operator=( const long long int& a );
+    BigInt& operator=( const double& a );
+    BigInt& operator=( BigInt&& a );
+
+    BigInt& operator+=( const unsigned& a );
+    BigInt& operator+=( const unsigned long& a );
+    BigInt& operator+=( const BigInt& a );
+
+    BigInt& operator-=( const unsigned& a );
+    BigInt& operator-=( const unsigned long& a );
+    BigInt& operator-=( const BigInt& a );
+
+    BigInt& operator*=( const int& a );
+    BigInt& operator*=( const long int& a );
+    BigInt& operator*=( const unsigned& a );
+    BigInt& operator*=( const unsigned long& a );
+    BigInt& operator*=( const BigInt& a );
+
+    BigInt& operator/=( const BigInt& a );
+
+    // Negation
+    BigInt operator-() const;
+
+    // Identity map
+    BigInt operator+() const;
+
+    // Analogue of bit-shifting left
+    BigInt& operator<<=( const int& a );
+    BigInt& operator<<=( const long int& a );
+    BigInt& operator<<=( const unsigned& a ); 
+    BigInt& operator<<=( const unsigned long& a );
+
+    // Analogue of bit-shifting right
+    BigInt& operator>>=( const int& a );
+    BigInt& operator>>=( const long int& a );
+    BigInt& operator>>=( const unsigned& a ); 
+    BigInt& operator>>=( const unsigned long& a );
+
+    // Casting
+    explicit operator bool() const;
+    explicit operator int() const;
+    explicit operator long() const;
+    explicit operator long long() const;
+    explicit operator unsigned() const;
+    explicit operator unsigned long() const;
+    explicit operator unsigned long long() const;
+    explicit operator float() const;
+    explicit operator double() const;
+    explicit operator long double() const;
+#ifdef EL_HAVE_QUAD
+    explicit operator Quad() const;
+#endif
+#ifdef EL_HAVE_QD
+    explicit operator DoubleDouble() const;
+    explicit operator QuadDouble() const;
+#endif
+
+    size_t SerializedSize( int numLimbs=mpc::NumIntLimbs() ) const;
+          byte* Serialize( byte* buf, int numLimbs=mpc::NumIntLimbs() ) const;
+          byte* Deserialize( byte* buf, int numLimbs=mpc::NumIntLimbs() );
+    const byte* Deserialize( const byte* buf, int numLimbs=mpc::NumIntLimbs() );
+
+    size_t ThinSerializedSize() const;
+          byte* ThinSerialize( byte* buf ) const;
+          byte* ThinDeserialize( byte* buf );
+    const byte* ThinDeserialize( const byte* buf );
+
+    friend BigInt operator%( const BigInt& a, const BigInt& b );
+    friend BigInt operator%( const BigInt& a, const unsigned& b );
+    friend BigInt operator%( const BigInt& a, const unsigned long& b );
+    friend bool operator<( const BigInt& a, const BigInt& b );
+    friend bool operator<( const BigInt& a, const int& b );
+    friend bool operator<( const BigInt& a, const long int& b );
+    friend bool operator<( const int& a, const BigInt& b );
+    friend bool operator<( const long int& a, const BigInt& b );
+    friend bool operator>( const BigInt& a, const BigInt& b );
+    friend bool operator>( const BigInt& a, const int& b );
+    friend bool operator>( const BigInt& a, const long int& b );
+    friend bool operator>( const int& a, const BigInt& b );
+    friend bool operator>( const long int& a, const BigInt& b );
+    friend bool operator<=( const BigInt& a, const BigInt& b );
+    friend bool operator<=( const BigInt& a, const int& b );
+    friend bool operator<=( const BigInt& a, const long int& b );
+    friend bool operator<=( const int& a, const BigInt& b );
+    friend bool operator<=( const long int& a, const BigInt& b );
+    friend bool operator>=( const BigInt& a, const BigInt& b );
+    friend bool operator>=( const BigInt& a, const int& b );
+    friend bool operator>=( const BigInt& a, const long int& b );
+    friend bool operator>=( const int& a, const BigInt& b );
+    friend bool operator>=( const long int& a, const BigInt& b );
+    friend bool operator==( const BigInt& a, const BigInt& b );
+    friend bool operator==( const BigInt& a, const int& b );
+    friend bool operator==( const BigInt& a, const long int& b );
+    friend bool operator==( const int& a, const BigInt& b );
+    friend bool operator==( const long int& a, const BigInt& b );
+};
+
+BigInt operator+( const BigInt& a, const BigInt& b );
+BigInt operator-( const BigInt& a, const BigInt& b );
+BigInt operator*( const BigInt& a, const BigInt& b );
+BigInt operator/( const BigInt& a, const BigInt& b );
+
+BigInt operator%( const BigInt& a, const BigInt& b );
+BigInt operator%( const BigInt& a, const unsigned& b );
+BigInt operator%( const BigInt& a, const unsigned long& b );
+
+BigInt operator<<( const BigInt& a, const int& b );
+BigInt operator<<( const BigInt& a, const long int& b );
+BigInt operator<<( const BigInt& a, const unsigned& b );
+BigInt operator<<( const BigInt& a, const unsigned long& b );
+
+BigInt operator>>( const BigInt& a, const int& b );
+BigInt operator>>( const BigInt& a, const long int& b );
+BigInt operator>>( const BigInt& a, const unsigned& b );
+BigInt operator>>( const BigInt& a, const unsigned long& b );
+
+bool operator<( const BigInt& a, const BigInt& b );
+bool operator<( const BigInt& a, const int& b );
+bool operator<( const BigInt& a, const long int& b );
+bool operator<( const int& a, const BigInt& b );
+bool operator<( const long int& a, const BigInt& b );
+bool operator>( const BigInt& a, const BigInt& b );
+bool operator>( const BigInt& a, const int& b );
+bool operator>( const BigInt& a, const long int& b );
+bool operator>( const int& a, const BigInt& b );
+bool operator>( const long int& a, const BigInt& b );
+bool operator<=( const BigInt& a, const BigInt& b );
+bool operator<=( const BigInt& a, const int& b );
+bool operator<=( const BigInt& a, const long int& b );
+bool operator<=( const int& a, const BigInt& b );
+bool operator<=( const long int& a, const BigInt& b );
+bool operator>=( const BigInt& a, const BigInt& b );
+bool operator>=( const BigInt& a, const int& b );
+bool operator>=( const BigInt& a, const long int& b );
+bool operator>=( const int& a, const BigInt& b );
+bool operator>=( const long int& a, const BigInt& b );
+bool operator==( const BigInt& a, const BigInt& b );
+bool operator==( const BigInt& a, const int& b );
+bool operator==( const BigInt& a, const long int& b );
+bool operator==( const int& a, const BigInt& b );
+bool operator==( const long int& a, const BigInt& b );
+bool operator!=( const BigInt& a, const BigInt& b );
+bool operator!=( const BigInt& a, const int& b );
+bool operator!=( const BigInt& a, const long int& b );
+bool operator!=( const int& a, const BigInt& b );
+bool operator!=( const long int& a, const BigInt& b );
+
+std::ostream& operator<<( std::ostream& os, const BigInt& alpha );
+std::istream& operator>>( std::istream& is,       BigInt& alpha );
+
+// BigRational class based upon mpq?
 
 // Since MPFR chose to have mpfr_t be a typedef to an array of length 1,
 // it is unnecessarily difficult to use with the STL. The following thus
@@ -65,6 +255,7 @@ public:
     //       constructors which accept an integer and an (optional) precision
     BigFloat();
     BigFloat( const BigFloat& a, mpfr_prec_t prec=mpc::Precision() );
+    BigFloat( const BigInt& a, mpfr_prec_t prec=mpc::Precision() );
     BigFloat( const unsigned& a, mpfr_prec_t prec=mpc::Precision() );
     BigFloat( const unsigned long& a, mpfr_prec_t prec=mpc::Precision() );
     BigFloat( const unsigned long long& a, mpfr_prec_t prec=mpc::Precision() );
@@ -80,8 +271,7 @@ public:
 #ifdef EL_HAVE_QUAD
     BigFloat( const Quad& a, mpfr_prec_t prec=mpc::Precision() );
 #endif
-    BigFloat
-    ( const char* str, int base, mpfr_prec_t prec=mpc::Precision() );
+    BigFloat( const char* str, int base, mpfr_prec_t prec=mpc::Precision() );
     BigFloat
     ( const std::string& str, int base, mpfr_prec_t prec=mpc::Precision() );
     BigFloat( BigFloat&& a );
@@ -90,6 +280,7 @@ public:
     void Zero();
 
     BigFloat& operator=( const BigFloat& a );
+    BigFloat& operator=( const BigInt& a );
 #ifdef EL_HAVE_QUAD
     BigFloat& operator=( const Quad& a );
 #endif
@@ -107,16 +298,36 @@ public:
     BigFloat& operator=( const unsigned long long& a );
     BigFloat& operator=( BigFloat&& a );
 
+    BigFloat& operator+=( const unsigned& a );
+    BigFloat& operator+=( const unsigned long& a );
+    BigFloat& operator+=( const int& a );
+    BigFloat& operator+=( const long int& a );
     BigFloat& operator+=( const double& a );
+    BigFloat& operator+=( const BigInt& a );
     BigFloat& operator+=( const BigFloat& a );
 
+    BigFloat& operator-=( const unsigned& a );
+    BigFloat& operator-=( const unsigned long& a );
+    BigFloat& operator-=( const int& a );
+    BigFloat& operator-=( const long int& a );
     BigFloat& operator-=( const double& a );
+    BigFloat& operator-=( const BigInt& a );
     BigFloat& operator-=( const BigFloat& a );
 
+    BigFloat& operator*=( const unsigned& a );
+    BigFloat& operator*=( const unsigned long& a );
+    BigFloat& operator*=( const int& a );
+    BigFloat& operator*=( const long int& a );
     BigFloat& operator*=( const double& a );
+    BigFloat& operator*=( const BigInt& a );
     BigFloat& operator*=( const BigFloat& a );
 
+    BigFloat& operator/=( const unsigned& a );
+    BigFloat& operator/=( const unsigned long& a );
+    BigFloat& operator/=( const int& a );
+    BigFloat& operator/=( const long int& a );
     BigFloat& operator/=( const double& a );
+    BigFloat& operator/=( const BigInt& a );
     BigFloat& operator/=( const BigFloat& a );
 
     // Negation
@@ -155,12 +366,14 @@ public:
 #ifdef EL_HAVE_QUAD
     explicit operator Quad() const;
 #endif
+    explicit operator BigInt() const;
 
     size_t SerializedSize() const;
           byte* Serialize( byte* buf ) const;
           byte* Deserialize( byte* buf );
     const byte* Deserialize( const byte* buf );
 
+    // Comparisons with BigInt via mpfr_cmp_z?
     friend bool operator<( const BigFloat& a, const BigFloat& b );
     friend bool operator>( const BigFloat& a, const BigFloat& b );
     friend bool operator<=( const BigFloat& a, const BigFloat& b );

--- a/include/El/core/imports/mpi.hpp
+++ b/include/El/core/imports/mpi.hpp
@@ -136,6 +136,8 @@ template<> Op MaxOp<Quad>() EL_NO_EXCEPT;
 template<> Op MinOp<Quad>() EL_NO_EXCEPT;
 #endif
 #ifdef EL_HAVE_MPC
+template<> Op MaxOp<BigInt>() EL_NO_EXCEPT;
+template<> Op MinOp<BigInt>() EL_NO_EXCEPT;
 template<> Op MaxOp<BigFloat>() EL_NO_EXCEPT;
 template<> Op MinOp<BigFloat>() EL_NO_EXCEPT;
 #endif
@@ -150,6 +152,7 @@ template<> Op SumOp<Quad>() EL_NO_EXCEPT;
 template<> Op SumOp<Complex<Quad>>() EL_NO_EXCEPT;
 #endif
 #ifdef EL_HAVE_MPC
+template<> Op SumOp<BigInt>() EL_NO_EXCEPT;
 template<> Op SumOp<BigFloat>() EL_NO_EXCEPT;
 #endif
 
@@ -172,6 +175,8 @@ template<> Op MaxLocOp<Quad>() EL_NO_EXCEPT;
 template<> Op MinLocOp<Quad>() EL_NO_EXCEPT;
 #endif
 #ifdef EL_HAVE_MPC
+template<> Op MaxLocOp<BigInt>() EL_NO_EXCEPT;
+template<> Op MinLocOp<BigInt>() EL_NO_EXCEPT;
 template<> Op MaxLocOp<BigFloat>() EL_NO_EXCEPT;
 template<> Op MinLocOp<BigFloat>() EL_NO_EXCEPT;
 #endif
@@ -195,6 +200,8 @@ template<> Op MaxLocPairOp<Quad>() EL_NO_EXCEPT;
 template<> Op MinLocPairOp<Quad>() EL_NO_EXCEPT;
 #endif
 #ifdef EL_HAVE_MPC
+template<> Op MaxLocPairOp<BigInt>() EL_NO_EXCEPT;
+template<> Op MinLocPairOp<BigInt>() EL_NO_EXCEPT;
 template<> Op MaxLocPairOp<BigFloat>() EL_NO_EXCEPT;
 template<> Op MinLocPairOp<BigFloat>() EL_NO_EXCEPT;
 #endif
@@ -305,6 +312,19 @@ EL_NO_RELEASE_EXCEPT;
 #ifdef EL_HAVE_MPC
 template<>
 void TaggedSend
+( const BigInt* buf, int count, int to, int tag, Comm comm )
+EL_NO_RELEASE_EXCEPT;
+template<>
+void TaggedSend
+( const ValueInt<BigInt>* buf, int count, int to, int tag, Comm comm )
+EL_NO_RELEASE_EXCEPT;
+template<>
+void TaggedSend
+( const Entry<BigInt>* buf, int count, int to, int tag, Comm comm )
+EL_NO_RELEASE_EXCEPT;
+
+template<>
+void TaggedSend
 ( const BigFloat* buf, int count, int to, int tag, Comm comm )
 EL_NO_RELEASE_EXCEPT;
 template<>
@@ -346,6 +366,21 @@ EL_NO_RELEASE_EXCEPT;
 //       buffer needs to persist despite being temporary internally
 template<>
 void TaggedISend
+( const BigInt* buf, int count, int to, int tag, Comm comm, Request& request )
+EL_NO_RELEASE_EXCEPT;
+template<>
+void TaggedISend
+( const ValueInt<BigInt>* buf, int count, int to, int tag,
+  Comm comm, Request& request )
+EL_NO_RELEASE_EXCEPT;
+template<>
+void TaggedISend
+( const Entry<BigInt>* buf, int count, int to, int tag,
+  Comm comm, Request& request )
+EL_NO_RELEASE_EXCEPT;
+
+template<>
+void TaggedISend
 ( const BigFloat* buf, int count, int to, int tag, Comm comm, Request& request )
 EL_NO_RELEASE_EXCEPT;
 template<>
@@ -385,6 +420,21 @@ void TaggedISSend
 ( const Real* buf, int count, int to, int tag, Comm comm, Request& request )
 EL_NO_RELEASE_EXCEPT;
 #ifdef EL_HAVE_MPC
+template<>
+void TaggedISSend
+( const BigInt* buf, int count, int to, int tag, Comm comm, Request& request )
+EL_NO_RELEASE_EXCEPT;
+template<>
+void TaggedISSend
+( const ValueInt<BigInt>* buf, int count, int to, int tag,
+  Comm comm, Request& request )
+EL_NO_RELEASE_EXCEPT;
+template<>
+void TaggedISSend
+( const Entry<BigInt>* buf, int count, int to, int tag,
+  Comm comm, Request& request )
+EL_NO_RELEASE_EXCEPT;
+
 template<>
 void TaggedISSend
 ( const BigFloat* buf, int count, int to, int tag, Comm comm, Request& request )
@@ -429,6 +479,19 @@ EL_NO_RELEASE_EXCEPT;
 #ifdef EL_HAVE_MPC
 template<>
 void TaggedRecv
+( BigInt* buf, int count, int from, int tag, Comm comm )
+EL_NO_RELEASE_EXCEPT;
+template<>
+void TaggedRecv
+( ValueInt<BigInt>* buf, int count, int from, int tag, Comm comm )
+EL_NO_RELEASE_EXCEPT;
+template<>
+void TaggedRecv
+( Entry<BigInt>* buf, int count, int from, int tag, Comm comm )
+EL_NO_RELEASE_EXCEPT;
+
+template<>
+void TaggedRecv
 ( BigFloat* buf, int count, int from, int tag, Comm comm )
 EL_NO_RELEASE_EXCEPT;
 template<>
@@ -469,6 +532,19 @@ void TaggedIRecv
 //       buffer needs to persist despite being temporary internally
 template<>
 void TaggedIRecv
+( BigInt* buf, int count, int from, int tag, Comm comm,
+  Request& request ) EL_NO_RELEASE_EXCEPT;
+template<>
+void TaggedIRecv
+( ValueInt<BigInt>* buf, int count, int from, int tag, Comm comm,
+  Request& request ) EL_NO_RELEASE_EXCEPT;
+template<>
+void TaggedIRecv
+( Entry<BigInt>* buf, int count, int from, int tag, Comm comm,
+  Request& request ) EL_NO_RELEASE_EXCEPT;
+
+template<>
+void TaggedIRecv
 ( BigFloat* buf, int count, int from, int tag, Comm comm,
   Request& request ) EL_NO_RELEASE_EXCEPT;
 template<>
@@ -507,6 +583,22 @@ void TaggedSendRecv
         Real* rbuf, int rc, int from, int rtag, Comm comm )
 EL_NO_RELEASE_EXCEPT;
 #ifdef EL_HAVE_MPC
+template<>
+void TaggedSendRecv
+( const BigInt* sbuf, int sc, int to,   int stag,
+        BigInt* rbuf, int rc, int from, int rtag, Comm comm )
+EL_NO_RELEASE_EXCEPT;
+template<>
+void TaggedSendRecv
+( const ValueInt<BigInt>* sbuf, int sc, int to,   int stag,
+        ValueInt<BigInt>* rbuf, int rc, int from, int rtag, Comm comm )
+EL_NO_RELEASE_EXCEPT;
+template<>
+void TaggedSendRecv
+( const Entry<BigInt>* sbuf, int sc, int to,   int stag,
+        Entry<BigInt>* rbuf, int rc, int from, int rtag, Comm comm )
+EL_NO_RELEASE_EXCEPT;
+
 template<>
 void TaggedSendRecv
 ( const BigFloat* sbuf, int sc, int to,   int stag,
@@ -554,6 +646,21 @@ EL_NO_RELEASE_EXCEPT;
 #ifdef EL_HAVE_MPC
 template<>
 void TaggedSendRecv
+( BigInt* buf, int count, int to, int stag, int from, int rtag, Comm comm )
+EL_NO_RELEASE_EXCEPT;
+template<>
+void TaggedSendRecv
+( ValueInt<BigInt>* buf, int count, int to, int stag, int from, int rtag,
+  Comm comm )
+EL_NO_RELEASE_EXCEPT;
+template<>
+void TaggedSendRecv
+( Entry<BigInt>* buf, int count, int to, int stag, int from, int rtag,
+  Comm comm )
+EL_NO_RELEASE_EXCEPT;
+
+template<>
+void TaggedSendRecv
 ( BigFloat* buf, int count, int to, int stag, int from, int rtag, Comm comm )
 EL_NO_RELEASE_EXCEPT;
 template<>
@@ -587,6 +694,16 @@ void Broadcast( Real* buf, int count, int root, Comm comm )
 EL_NO_RELEASE_EXCEPT;
 #ifdef EL_HAVE_MPC
 template<>
+void Broadcast( BigInt* buf, int count, int root, Comm comm )
+EL_NO_RELEASE_EXCEPT;
+template<>
+void Broadcast( ValueInt<BigInt>* buf, int count, int root, Comm comm )
+EL_NO_RELEASE_EXCEPT;
+template<>
+void Broadcast( Entry<BigInt>* buf, int count, int root, Comm comm )
+EL_NO_RELEASE_EXCEPT;
+
+template<>
 void Broadcast( BigFloat* buf, int count, int root, Comm comm )
 EL_NO_RELEASE_EXCEPT;
 template<>
@@ -610,6 +727,16 @@ template<typename Real>
 void IBroadcast
 ( Real* buf, int count, int root, Comm comm, Request& request );
 #ifdef EL_HAVE_MPC
+template<>
+void IBroadcast
+( BigInt* buf, int count, int root, Comm comm, Request& request );
+template<>
+void IBroadcast
+( ValueInt<BigInt>* buf, int count, int root, Comm comm, Request& request );
+template<>
+void IBroadcast
+( Entry<BigInt>* buf, int count, int root, Comm comm, Request& request );
+
 template<>
 void IBroadcast
 ( BigFloat* buf, int count, int root, Comm comm, Request& request );
@@ -643,6 +770,21 @@ void Gather
 #ifdef EL_HAVE_MPC
 template<>
 void Gather
+( const BigInt* sbuf, int sc,
+        BigInt* rbuf, int rc, int root, Comm comm ) EL_NO_RELEASE_EXCEPT;
+template<>
+void Gather
+( const ValueInt<BigInt>* sbuf, int sc,
+        ValueInt<BigInt>* rbuf, int rc,
+  int root, Comm comm ) EL_NO_RELEASE_EXCEPT;
+template<>
+void Gather
+( const Entry<BigInt>* sbuf, int sc,
+        Entry<BigInt>* rbuf, int rc,
+  int root, Comm comm ) EL_NO_RELEASE_EXCEPT;
+
+template<>
+void Gather
 ( const BigFloat* sbuf, int sc,
         BigFloat* rbuf, int rc, int root, Comm comm ) EL_NO_RELEASE_EXCEPT;
 template<>
@@ -668,6 +810,21 @@ void IGather
 ( const Real* sbuf, int sc,
         Real* rbuf, int rc, int root, Comm comm, Request& request );
 #ifdef EL_HAVE_MPC
+template<>
+void IGather
+( const BigInt* sbuf, int sc,
+        BigInt* rbuf, int rc, int root, Comm comm, Request& request );
+template<>
+void IGather
+( const ValueInt<BigInt>* sbuf, int sc,
+        ValueInt<BigInt>* rbuf, int rc,
+  int root, Comm comm, Request& request );
+template<>
+void IGather
+( const Entry<BigInt>* sbuf, int sc,
+        Entry<BigInt>* rbuf, int rc,
+  int root, Comm comm, Request& request );
+
 template<>
 void IGather
 ( const BigFloat* sbuf, int sc,
@@ -697,6 +854,25 @@ void Gather
   int root, Comm comm )
 EL_NO_RELEASE_EXCEPT;
 #ifdef EL_HAVE_MPC
+template<>
+void Gather
+( const BigInt* sbuf, int sc,
+        BigInt* rbuf, const int* rcs, const int* rds,
+  int root, Comm comm )
+EL_NO_RELEASE_EXCEPT;
+template<>
+void Gather
+( const ValueInt<BigInt>* sbuf, int sc,
+        ValueInt<BigInt>* rbuf, const int* rcs, const int* rds,
+  int root, Comm comm )
+EL_NO_RELEASE_EXCEPT;
+template<>
+void Gather
+( const Entry<BigInt>* sbuf, int sc,
+        Entry<BigInt>* rbuf, const int* rcs, const int* rds,
+  int root, Comm comm )
+EL_NO_RELEASE_EXCEPT;
+
 template<>
 void Gather
 ( const BigFloat* sbuf, int sc,
@@ -732,6 +908,19 @@ void AllGather
 #ifdef EL_HAVE_MPC
 template<>
 void AllGather
+( const BigInt* sbuf, int sc,
+        BigInt* rbuf, int rc, Comm comm ) EL_NO_RELEASE_EXCEPT;
+template<>
+void AllGather
+( const ValueInt<BigInt>* sbuf, int sc,
+        ValueInt<BigInt>* rbuf, int rc, Comm comm ) EL_NO_RELEASE_EXCEPT;
+template<>
+void AllGather
+( const Entry<BigInt>* sbuf, int sc,
+        Entry<BigInt>* rbuf, int rc, Comm comm ) EL_NO_RELEASE_EXCEPT;
+
+template<>
+void AllGather
 ( const BigFloat* sbuf, int sc,
         BigFloat* rbuf, int rc, Comm comm ) EL_NO_RELEASE_EXCEPT;
 template<>
@@ -756,6 +945,22 @@ void AllGather
         Real* rbuf, const int* rcs, const int* rds, Comm comm )
 EL_NO_RELEASE_EXCEPT;
 #ifdef EL_HAVE_MPC
+template<>
+void AllGather
+( const BigInt* sbuf, int sc,
+        BigInt* rbuf, const int* rcs, const int* rds, Comm comm )
+EL_NO_RELEASE_EXCEPT;
+template<>
+void AllGather
+( const ValueInt<BigInt>* sbuf, int sc,
+        ValueInt<BigInt>* rbuf, const int* rcs, const int* rds, Comm comm )
+EL_NO_RELEASE_EXCEPT;
+template<>
+void AllGather
+( const Entry<BigInt>* sbuf, int sc,
+        Entry<BigInt>* rbuf, const int* rcs, const int* rds, Comm comm )
+EL_NO_RELEASE_EXCEPT;
+
 template<>
 void AllGather
 ( const BigFloat* sbuf, int sc,
@@ -789,6 +994,22 @@ EL_NO_RELEASE_EXCEPT;
 #ifdef EL_HAVE_MPC
 template<>
 void Scatter
+( const BigInt* sbuf, int sc,
+        BigInt* rbuf, int rc, int root, Comm comm )
+EL_NO_RELEASE_EXCEPT;
+template<>
+void Scatter
+( const ValueInt<BigInt>* sbuf, int sc,
+        ValueInt<BigInt>* rbuf, int rc, int root, Comm comm )
+EL_NO_RELEASE_EXCEPT;
+template<>
+void Scatter
+( const Entry<BigInt>* sbuf, int sc,
+        Entry<BigInt>* rbuf, int rc, int root, Comm comm )
+EL_NO_RELEASE_EXCEPT;
+
+template<>
+void Scatter
 ( const BigFloat* sbuf, int sc,
         BigFloat* rbuf, int rc, int root, Comm comm )
 EL_NO_RELEASE_EXCEPT;
@@ -814,6 +1035,16 @@ void Scatter( Real* buf, int sc, int rc, int root, Comm comm )
 EL_NO_RELEASE_EXCEPT;
 #ifdef EL_HAVE_MPC
 template<>
+void Scatter( BigInt* buf, int sc, int rc, int root, Comm comm )
+EL_NO_RELEASE_EXCEPT;
+template<>
+void Scatter( ValueInt<BigInt>* buf, int sc, int rc, int root, Comm comm )
+EL_NO_RELEASE_EXCEPT;
+template<>
+void Scatter( Entry<BigInt>* buf, int sc, int rc, int root, Comm comm )
+EL_NO_RELEASE_EXCEPT;
+
+template<>
 void Scatter( BigFloat* buf, int sc, int rc, int root, Comm comm )
 EL_NO_RELEASE_EXCEPT;
 template<>
@@ -837,6 +1068,19 @@ void AllToAll
 ( const Real* sbuf, int sc,
         Real* rbuf, int rc, Comm comm ) EL_NO_RELEASE_EXCEPT;
 #ifdef EL_HAVE_MPC
+template<>
+void AllToAll
+( const BigInt* sbuf, int sc,
+        BigInt* rbuf, int rc, Comm comm ) EL_NO_RELEASE_EXCEPT;
+template<>
+void AllToAll
+( const ValueInt<BigInt>* sbuf, int sc,
+        ValueInt<BigInt>* rbuf, int rc, Comm comm ) EL_NO_RELEASE_EXCEPT;
+template<>
+void AllToAll
+( const Entry<BigInt>* sbuf, int sc,
+        Entry<BigInt>* rbuf, int rc, Comm comm ) EL_NO_RELEASE_EXCEPT;
+
 template<>
 void AllToAll
 ( const BigFloat* sbuf, int sc,
@@ -864,6 +1108,22 @@ void AllToAll
         Real* rbuf, const int* rcs, const int* rds, Comm comm )
 EL_NO_RELEASE_EXCEPT;
 #ifdef EL_HAVE_MPC
+template<>
+void AllToAll
+( const BigInt* sbuf, const int* scs, const int* sds,
+        BigInt* rbuf, const int* rcs, const int* rds, Comm comm )
+EL_NO_RELEASE_EXCEPT;
+template<>
+void AllToAll
+( const ValueInt<BigInt>* sbuf, const int* scs, const int* sds,
+        ValueInt<BigInt>* rbuf, const int* rcs, const int* rds, Comm comm )
+EL_NO_RELEASE_EXCEPT;
+template<>
+void AllToAll
+( const Entry<BigInt>* sbuf, const int* scs, const int* sds,
+        Entry<BigInt>* rbuf, const int* rcs, const int* rds, Comm comm )
+EL_NO_RELEASE_EXCEPT;
+
 template<>
 void AllToAll
 ( const BigFloat* sbuf, const int* scs, const int* sds,
@@ -901,6 +1161,21 @@ void Reduce
 ( const Real* sbuf, Real* rbuf, int count, Op op, int root, Comm comm )
 EL_NO_RELEASE_EXCEPT;
 #ifdef EL_HAVE_MPC
+template<>
+void Reduce
+( const BigInt* sbuf, BigInt* rbuf, int count, Op op, int root, Comm comm )
+EL_NO_RELEASE_EXCEPT;
+template<>
+void Reduce
+( const ValueInt<BigInt>* sbuf,
+        ValueInt<BigInt>* rbuf, int count, Op op, int root, Comm comm )
+EL_NO_RELEASE_EXCEPT;
+template<>
+void Reduce
+( const Entry<BigInt>* sbuf,
+        Entry<BigInt>* rbuf, int count, Op op, int root, Comm comm )
+EL_NO_RELEASE_EXCEPT;
+
 template<>
 void Reduce
 ( const BigFloat* sbuf, BigFloat* rbuf, int count, Op op, int root, Comm comm )
@@ -966,6 +1241,16 @@ void Reduce( Real* buf, int count, Op op, int root, Comm comm )
 EL_NO_RELEASE_EXCEPT;
 #ifdef EL_HAVE_MPC
 template<>
+void Reduce( BigInt* buf, int count, Op op, int root, Comm comm )
+EL_NO_RELEASE_EXCEPT;
+template<>
+void Reduce( ValueInt<BigInt>* buf, int count, Op op, int root, Comm comm )
+EL_NO_RELEASE_EXCEPT;
+template<>
+void Reduce( Entry<BigInt>* buf, int count, Op op, int root, Comm comm )
+EL_NO_RELEASE_EXCEPT;
+
+template<>
 void Reduce( BigFloat* buf, int count, Op op, int root, Comm comm )
 EL_NO_RELEASE_EXCEPT;
 template<>
@@ -1001,6 +1286,21 @@ template<typename Real>
 void AllReduce( const Real* sbuf, Real* rbuf, int count, Op op, Comm comm )
 EL_NO_RELEASE_EXCEPT;
 #ifdef EL_HAVE_MPC
+template<>
+void AllReduce
+( const BigInt* sbuf, BigInt* rbuf, int count, Op op, Comm comm )
+EL_NO_RELEASE_EXCEPT;
+template<>
+void AllReduce
+( const ValueInt<BigInt>* sbuf,
+        ValueInt<BigInt>* rbuf, int count, Op op, Comm comm )
+EL_NO_RELEASE_EXCEPT;
+template<>
+void AllReduce
+( const Entry<BigInt>* sbuf,
+        Entry<BigInt>* rbuf, int count, Op op, Comm comm )
+EL_NO_RELEASE_EXCEPT;
+
 template<>
 void AllReduce
 ( const BigFloat* sbuf, BigFloat* rbuf, int count, Op op, Comm comm )
@@ -1066,6 +1366,16 @@ void AllReduce( Real* buf, int count, Op op, Comm comm )
 EL_NO_RELEASE_EXCEPT;
 #ifdef EL_HAVE_MPC
 template<>
+void AllReduce( BigInt* buf, int count, Op op, Comm comm )
+EL_NO_RELEASE_EXCEPT;
+template<>
+void AllReduce( ValueInt<BigInt>* buf, int count, Op op, Comm comm )
+EL_NO_RELEASE_EXCEPT;
+template<>
+void AllReduce( Entry<BigInt>* buf, int count, Op op, Comm comm )
+EL_NO_RELEASE_EXCEPT;
+
+template<>
 void AllReduce( BigFloat* buf, int count, Op op, Comm comm )
 EL_NO_RELEASE_EXCEPT;
 template<>
@@ -1101,6 +1411,18 @@ template<typename Real>
 void ReduceScatter( Real* sbuf, Real* rbuf, int rc, Op op, Comm comm )
 EL_NO_RELEASE_EXCEPT;
 #ifdef EL_HAVE_MPC
+template<>
+void ReduceScatter( BigInt* sbuf, BigInt* rbuf, int rc, Op op, Comm comm )
+EL_NO_RELEASE_EXCEPT;
+template<>
+void ReduceScatter
+( ValueInt<BigInt>* sbuf, ValueInt<BigInt>* rbuf, int rc, Op op, Comm comm )
+EL_NO_RELEASE_EXCEPT;
+template<>
+void ReduceScatter
+( Entry<BigInt>* sbuf, Entry<BigInt>* rbuf, int rc, Op op, Comm comm )
+EL_NO_RELEASE_EXCEPT;
+
 template<>
 void ReduceScatter( BigFloat* sbuf, BigFloat* rbuf, int rc, Op op, Comm comm )
 EL_NO_RELEASE_EXCEPT;
@@ -1142,6 +1464,16 @@ void ReduceScatter( Real* buf, int rc, Op op, Comm comm )
 EL_NO_RELEASE_EXCEPT;
 #ifdef EL_HAVE_MPC
 template<>
+void ReduceScatter( BigInt* buf, int rc, Op op, Comm comm )
+EL_NO_RELEASE_EXCEPT;
+template<>
+void ReduceScatter( ValueInt<BigInt>* buf, int rc, Op op, Comm comm )
+EL_NO_RELEASE_EXCEPT;
+template<>
+void ReduceScatter( Entry<BigInt>* buf, int rc, Op op, Comm comm )
+EL_NO_RELEASE_EXCEPT;
+
+template<>
 void ReduceScatter( BigFloat* buf, int rc, Op op, Comm comm )
 EL_NO_RELEASE_EXCEPT;
 template<>
@@ -1178,6 +1510,21 @@ void ReduceScatter
 ( const Real* sbuf, Real* rbuf, const int* rcs, Op op, Comm comm )
 EL_NO_RELEASE_EXCEPT;
 #ifdef EL_HAVE_MPC
+template<>
+void ReduceScatter
+( const BigInt* sbuf, BigInt* rbuf, const int* rcs, Op op, Comm comm )
+EL_NO_RELEASE_EXCEPT;
+template<>
+void ReduceScatter
+( const ValueInt<BigInt>* sbuf,
+        ValueInt<BigInt>* rbuf, const int* rcs, Op op, Comm comm )
+EL_NO_RELEASE_EXCEPT;
+template<>
+void ReduceScatter
+( const Entry<BigInt>* sbuf,
+        Entry<BigInt>* rbuf, const int* rcs, Op op, Comm comm )
+EL_NO_RELEASE_EXCEPT;
+
 template<>
 void ReduceScatter
 ( const BigFloat* sbuf, BigFloat* rbuf, const int* rcs, Op op, Comm comm )
@@ -1222,6 +1569,20 @@ template<typename Real>
 void Scan( const Real* sbuf, Real* rbuf, int count, Op op, Comm comm )
 EL_NO_RELEASE_EXCEPT;
 #ifdef EL_HAVE_MPC
+template<>
+void Scan( const BigInt* sbuf, BigInt* rbuf, int count, Op op, Comm comm )
+EL_NO_RELEASE_EXCEPT;
+template<>
+void Scan
+( const ValueInt<BigInt>* sbuf,
+        ValueInt<BigInt>* rbuf, int count, Op op, Comm comm )
+EL_NO_RELEASE_EXCEPT;
+template<>
+void Scan
+( const Entry<BigInt>* sbuf,
+        Entry<BigInt>* rbuf, int count, Op op, Comm comm )
+EL_NO_RELEASE_EXCEPT;
+
 template<>
 void Scan( const BigFloat* sbuf, BigFloat* rbuf, int count, Op op, Comm comm )
 EL_NO_RELEASE_EXCEPT;
@@ -1284,6 +1645,16 @@ template<typename Real>
 void Scan( Real* buf, int count, Op op, Comm comm )
 EL_NO_RELEASE_EXCEPT;
 #ifdef EL_HAVE_MPC
+template<>
+void Scan( BigInt* buf, int count, Op op, Comm comm )
+EL_NO_RELEASE_EXCEPT;
+template<>
+void Scan( ValueInt<BigInt>* buf, int count, Op op, Comm comm )
+EL_NO_RELEASE_EXCEPT;
+template<>
+void Scan( Entry<BigInt>* buf, int count, Op op, Comm comm )
+EL_NO_RELEASE_EXCEPT;
+
 template<>
 void Scan( BigFloat* buf, int count, Op op, Comm comm )
 EL_NO_RELEASE_EXCEPT;
@@ -1355,6 +1726,7 @@ template<> Datatype TypeMap<Quad>() EL_NO_EXCEPT;
 template<> Datatype TypeMap<Complex<Quad>>() EL_NO_EXCEPT;
 #endif
 #ifdef EL_HAVE_MPC
+template<> Datatype TypeMap<BigInt>() EL_NO_EXCEPT;
 template<> Datatype TypeMap<BigFloat>() EL_NO_EXCEPT;
 #endif
 
@@ -1372,6 +1744,7 @@ template<> Datatype TypeMap<ValueInt<Quad>>() EL_NO_EXCEPT;
 template<> Datatype TypeMap<ValueInt<Complex<Quad>>>() EL_NO_EXCEPT;
 #endif
 #ifdef EL_HAVE_MPC
+template<> Datatype TypeMap<ValueInt<BigInt>>() EL_NO_EXCEPT;
 template<> Datatype TypeMap<ValueInt<BigFloat>>() EL_NO_EXCEPT;
 #endif
 
@@ -1389,10 +1762,13 @@ template<> Datatype TypeMap<Entry<Quad>>() EL_NO_EXCEPT;
 template<> Datatype TypeMap<Entry<Complex<Quad>>>() EL_NO_EXCEPT;
 #endif
 #ifdef EL_HAVE_MPC
+template<> Datatype TypeMap<Entry<BigInt>>() EL_NO_EXCEPT;
 template<> Datatype TypeMap<Entry<BigFloat>>() EL_NO_EXCEPT;
 #endif
 
 #ifdef EL_HAVE_MPC
+void CreateBigIntFamily();
+void DestroyBigIntFamily();
 void CreateBigFloatFamily();
 void DestroyBigFloatFamily();
 #endif

--- a/include/El/core/indexing/decl.hpp
+++ b/include/El/core/indexing/decl.hpp
@@ -49,6 +49,12 @@ Int GlobalBlockedIndex( Int iLoc, Int shift, Int bsize, Int cut, Int numProcs );
 // still returns a result in [0,b). Note that b is assumed to be non-negative.
 Int Mod( Int a, Int b );
 Int Mod_( Int a, Int b ) EL_NO_EXCEPT;
+#ifdef EL_HAVE_MPC
+BigInt Mod( const BigInt& a, const BigInt& b );
+BigInt Mod( const BigInt& a, const unsigned& b );
+BigInt Mod( const BigInt& a, const unsigned long& b );
+BigInt Mod_( const BigInt& a, const BigInt& b );
+#endif
 
 Int Shift( Int rank, Int firstRank, Int numProcs );
 Int Shift_( Int rank, Int firstRank, Int numProcs ) EL_NO_EXCEPT;

--- a/include/El/core/indexing/impl.hpp
+++ b/include/El/core/indexing/impl.hpp
@@ -183,6 +183,39 @@ inline Int Mod_( Int a, Int b ) EL_NO_EXCEPT
     return ( rem >= 0 ? rem : rem+b );
 }
 
+#ifdef EL_HAVE_MPC
+inline BigInt Mod( const BigInt& a, const BigInt& b )
+{
+    DEBUG_ONLY(
+      CSE cse("Mod");
+      if( b <= 0 )
+          LogicError("b is assumed to be positive");
+    )
+    return Mod_( a, b );
+}
+
+inline BigInt Mod( const BigInt& a, const unsigned& b )
+{
+    DEBUG_ONLY(CSE cse("Mod"))
+    const BigInt rem = a % b;
+    return ( rem >= 0 ? rem : rem+b );
+}
+
+inline BigInt Mod( const BigInt& a, const unsigned long& b )
+{
+    DEBUG_ONLY(CSE cse("Mod"))
+    const BigInt rem = a % b;
+    return ( rem >= 0 ? rem : rem+b );
+}
+
+inline BigInt Mod_( const BigInt& a, const BigInt& b )
+{
+    // TODO: Use a native routine for this
+    const BigInt rem = a % b;
+    return ( rem >= 0 ? rem : rem+b );
+}
+#endif
+
 // For determining the first index assigned to a given rank
 inline Int Shift( Int rank, Int align, Int stride )
 {

--- a/include/El/core/random/decl.hpp
+++ b/include/El/core/random/decl.hpp
@@ -34,25 +34,28 @@ template<typename T>
 T UnitCell();
 
 template<typename T=double>
-T SampleUniform( T a=0, T b=UnitCell<T>() );
+T SampleUniform( const T& a=0, const T& b=UnitCell<T>() );
 
 template<>
-Int SampleUniform<Int>( Int a, Int b );
+Int SampleUniform<Int>( const Int& a, const Int& b );
+
 #ifdef EL_HAVE_QD
 template<>
-DoubleDouble SampleUniform( DoubleDouble a, DoubleDouble b );
+DoubleDouble SampleUniform( const DoubleDouble& a, const DoubleDouble& b );
 template<>
-QuadDouble SampleUniform( QuadDouble a, QuadDouble b );
+QuadDouble SampleUniform( const QuadDouble& a, const QuadDouble& b );
 #endif
 #ifdef EL_HAVE_QUAD
 template<>
-Quad SampleUniform( Quad a, Quad b );
+Quad SampleUniform( const Quad& a, const Quad& b );
 template<>
-Complex<Quad> SampleUniform( Complex<Quad> a, Complex<Quad> b );
+Complex<Quad> SampleUniform( const Complex<Quad>& a, const Complex<Quad>& b );
 #endif
 #ifdef EL_HAVE_MPC
 template<>
-BigFloat SampleUniform( BigFloat a, BigFloat b );
+BigInt SampleUniform( const BigInt& a, const BigInt& b );
+template<>
+BigFloat SampleUniform( const BigFloat& a, const BigFloat& b );
 #endif
 
 // The complex extension of the normal distribution can actually be quite
@@ -60,33 +63,33 @@ BigFloat SampleUniform( BigFloat a, BigFloat b );
 // imaginary components are independently drawn with the same standard 
 // deviation, but different means.
 template<typename T=double>
-T SampleNormal( T mean=0, Base<T> stddev=1 );
+T SampleNormal( const T& mean=0, const Base<T>& stddev=1 );
 
 #ifdef EL_HAVE_QD
 template<>
-DoubleDouble SampleNormal( DoubleDouble mean, DoubleDouble stddev );
+DoubleDouble
+SampleNormal( const DoubleDouble& mean, const DoubleDouble& stddev );
 template<>
-QuadDouble SampleNormal( QuadDouble mean, QuadDouble stddev );
+QuadDouble
+SampleNormal( const QuadDouble& mean, const QuadDouble& stddev );
 #endif
 #ifdef EL_HAVE_QUAD
 template<>
-Quad SampleNormal( Quad mean, Quad stddev );
+Quad SampleNormal( const Quad& mean, const Quad& stddev );
 template<>
-Complex<Quad> SampleNormal( Complex<Quad> mean, Quad stddev );
+Complex<Quad> SampleNormal( const Complex<Quad>& mean, const Quad& stddev );
 #endif
 #ifdef EL_HAVE_MPC
 template<>
-BigFloat SampleNormal( BigFloat mean, BigFloat stddev );
+BigFloat SampleNormal( const BigFloat& mean, const BigFloat& stddev );
 #endif
 
 // Generate a sample from a uniform PDF over the (closed) unit ball about the 
 // origin of the ring implied by the type T using the most natural metric.
 template<typename F> 
-F SampleBall( F center=0, Base<F> radius=1 );
+F SampleBall( const F& center=0, const Base<F>& radius=1 );
 template<typename Real,typename=EnableIf<IsReal<Real>>> 
-Real SampleBall( Real center=0, Real radius=1 );
-// This does not yet have a good definition
-template<> Int SampleBall<Int>( Int center, Int radius );
+Real SampleBall( const Real& center=0, const Real& radius=1 );
 
 } // namespace El
 

--- a/include/El/core/random/impl.hpp
+++ b/include/El/core/random/impl.hpp
@@ -111,7 +111,7 @@ T UnitCell()
 }
 
 template<typename T>
-T SampleUniform( T a, T b )
+T SampleUniform( const T& a, const T& b )
 {
     typedef Base<T> Real;
     T sample;
@@ -143,20 +143,22 @@ T SampleUniform( T a, T b )
 }
 
 template<typename F>
-F SampleNormal( F mean, Base<F> stddev )
+F SampleNormal( const F& mean, const Base<F>& stddev )
 {
     typedef Base<F> Real;
     F sample;
+
+    Real stddevAdj = stddev;
     if( IsComplex<F>::value )
-        stddev = stddev / Sqrt(Real(2));
+        stddevAdj /= Sqrt(Real(2));
 
 #ifdef EL_HAVE_CXX11RANDOM
     std::mt19937& gen = Generator();
-    std::normal_distribution<Real> realNormal( RealPart(mean), stddev );
+    std::normal_distribution<Real> realNormal( RealPart(mean), stddevAdj );
     SetRealPart( sample, realNormal(gen) );
     if( IsComplex<F>::value )
     {
-        std::normal_distribution<Real> imagNormal( ImagPart(mean), stddev );
+        std::normal_distribution<Real> imagNormal( ImagPart(mean), stddevAdj );
         SetImagPart( sample, imagNormal(gen) );
     }
 #else
@@ -172,9 +174,9 @@ F SampleNormal( F mean, Base<F> stddev )
         if( S > Real(0) && S < Real(1) )
         {
             const Real W = Sqrt(-2*Log(S)/S);
-            SetRealPart( sample, RealPart(mean) + stddev*U*W );
+            SetRealPart( sample, RealPart(mean) + stddevAdj*U*W );
             if( IsComplex<F>::value )
-                SetImagPart( sample, ImagPart(mean) + stddev*V*W );
+                SetImagPart( sample, ImagPart(mean) + stddevAdj*V*W );
             break;
         }
     }
@@ -184,7 +186,7 @@ F SampleNormal( F mean, Base<F> stddev )
 }
 
 template<typename F>
-F SampleBall( F center, Base<F> radius )
+F SampleBall( const F& center, const Base<F>& radius )
 {
     typedef Base<F> Real;
     const Real r = SampleUniform<Real>(0,radius);
@@ -193,7 +195,7 @@ F SampleBall( F center, Base<F> radius )
 }
 
 template<typename Real,typename>
-Real SampleBall( Real center, Real radius )
+Real SampleBall( const Real& center, const Real& radius )
 { return SampleUniform<Real>(center-radius,center+radius); }
 
 } // namespace El

--- a/include/El/macros/Instantiate.h
+++ b/include/El/macros/Instantiate.h
@@ -38,6 +38,12 @@
 #endif
 #endif
 
+#if defined(EL_HAVE_MPC) && defined(EL_ENABLE_BIGINT)
+#ifndef PROTO_BIGINT
+# define PROTO_BIGINT PROTO_INT(BigInt)
+#endif
+#endif
+
 #if defined(EL_HAVE_MPC) && defined(EL_ENABLE_BIGFLOAT)
 #ifndef PROTO_BIGFLOAT
 # define PROTO_BIGFLOAT PROTO_REAL(BigFloat)
@@ -62,6 +68,9 @@
 
 #ifndef EL_NO_INT_PROTO
 PROTO_INT(Int)
+#if defined(EL_ENABLE_BIGINT) && defined(EL_HAVE_MPC)
+PROTO_BIGINT
+#endif
 #endif
 
 #ifndef EL_NO_REAL_PROTO

--- a/src/blas_like/level1/AllReduce.cpp
+++ b/src/blas_like/level1/AllReduce.cpp
@@ -90,6 +90,7 @@ void AllReduce( AbstractDistMatrix<T>& A, mpi::Comm comm, mpi::Op op )
 #define EL_ENABLE_DOUBLEDOUBLE
 #define EL_ENABLE_QUADDOUBLE
 #define EL_ENABLE_QUAD
+#define EL_ENABLE_BIGINT
 #define EL_ENABLE_BIGFLOAT
 #include "El/macros/Instantiate.h"
 

--- a/src/blas_like/level1/AxpyContract.cpp
+++ b/src/blas_like/level1/AxpyContract.cpp
@@ -487,6 +487,7 @@ void AxpyContract
 #define EL_ENABLE_DOUBLEDOUBLE
 #define EL_ENABLE_QUADDOUBLE
 #define EL_ENABLE_QUAD
+#define EL_ENABLE_BIGINT
 #define EL_ENABLE_BIGFLOAT
 #include "El/macros/Instantiate.h"
 

--- a/src/blas_like/level1/Broadcast.cpp
+++ b/src/blas_like/level1/Broadcast.cpp
@@ -97,6 +97,7 @@ void Broadcast( AbstractDistMatrix<T>& A, mpi::Comm comm, int rank )
 #define EL_ENABLE_DOUBLEDOUBLE
 #define EL_ENABLE_QUADDOUBLE
 #define EL_ENABLE_QUAD
+#define EL_ENABLE_BIGINT
 #define EL_ENABLE_BIGFLOAT
 #include "El/macros/Instantiate.h"
 

--- a/src/blas_like/level1/Concatenate.cpp
+++ b/src/blas_like/level1/Concatenate.cpp
@@ -314,6 +314,7 @@ void VCat
 #define EL_ENABLE_DOUBLEDOUBLE
 #define EL_ENABLE_QUADDOUBLE
 #define EL_ENABLE_QUAD
+#define EL_ENABLE_BIGINT
 #define EL_ENABLE_BIGFLOAT
 #include "El/macros/Instantiate.h"
 

--- a/src/blas_like/level1/Conjugate.cpp
+++ b/src/blas_like/level1/Conjugate.cpp
@@ -61,6 +61,7 @@ void Conjugate( const ElementalMatrix<T>& A, ElementalMatrix<T>& B )
 #define EL_ENABLE_DOUBLEDOUBLE
 #define EL_ENABLE_QUADDOUBLE
 #define EL_ENABLE_QUAD
+#define EL_ENABLE_BIGINT
 #define EL_ENABLE_BIGFLOAT
 #include "El/macros/Instantiate.h"
 

--- a/src/blas_like/level1/ConjugateDiagonal.cpp
+++ b/src/blas_like/level1/ConjugateDiagonal.cpp
@@ -51,6 +51,7 @@ void ConjugateDiagonal( AbstractDistMatrix<T>& A, Int offset )
 #define EL_ENABLE_DOUBLEDOUBLE
 #define EL_ENABLE_QUADDOUBLE
 #define EL_ENABLE_QUAD
+#define EL_ENABLE_BIGINT
 #define EL_ENABLE_BIGFLOAT
 #include "El/macros/Instantiate.h"
 

--- a/src/blas_like/level1/ConjugateSubmatrix.cpp
+++ b/src/blas_like/level1/ConjugateSubmatrix.cpp
@@ -70,6 +70,7 @@ void ConjugateSubmatrix
 #define EL_ENABLE_DOUBLEDOUBLE
 #define EL_ENABLE_QUADDOUBLE
 #define EL_ENABLE_QUAD
+#define EL_ENABLE_BIGINT
 #define EL_ENABLE_BIGFLOAT
 #include "El/macros/Instantiate.h"
 

--- a/src/blas_like/level1/Fill.cpp
+++ b/src/blas_like/level1/Fill.cpp
@@ -82,6 +82,7 @@ void Fill( DistSparseMatrix<T>& A, T alpha )
 #define EL_ENABLE_DOUBLEDOUBLE
 #define EL_ENABLE_QUADDOUBLE
 #define EL_ENABLE_QUAD
+#define EL_ENABLE_BIGINT
 #define EL_ENABLE_BIGFLOAT
 #include "El/macros/Instantiate.h"
 

--- a/src/blas_like/level1/Full.cpp
+++ b/src/blas_like/level1/Full.cpp
@@ -30,6 +30,7 @@ Matrix<T> Full( const SparseMatrix<T>& A )
 #define EL_ENABLE_DOUBLEDOUBLE
 #define EL_ENABLE_QUADDOUBLE
 #define EL_ENABLE_QUAD
+#define EL_ENABLE_BIGINT
 #define EL_ENABLE_BIGFLOAT
 #include "El/macros/Instantiate.h"
 

--- a/src/blas_like/level1/Hadamard.cpp
+++ b/src/blas_like/level1/Hadamard.cpp
@@ -86,6 +86,7 @@ void Hadamard
 #define EL_ENABLE_DOUBLEDOUBLE
 #define EL_ENABLE_QUADDOUBLE
 #define EL_ENABLE_QUAD
+#define EL_ENABLE_BIGINT
 #define EL_ENABLE_BIGFLOAT
 #include "El/macros/Instantiate.h"
 

--- a/src/blas_like/level1/HilbertSchmidt.cpp
+++ b/src/blas_like/level1/HilbertSchmidt.cpp
@@ -117,6 +117,7 @@ T HilbertSchmidt( const DistMultiVec<T>& A, const DistMultiVec<T>& B )
 #define EL_ENABLE_DOUBLEDOUBLE
 #define EL_ENABLE_QUADDOUBLE
 #define EL_ENABLE_QUAD
+#define EL_ENABLE_BIGINT
 #define EL_ENABLE_BIGFLOAT
 #include "El/macros/Instantiate.h"
 

--- a/src/blas_like/level1/ImagPart.cpp
+++ b/src/blas_like/level1/ImagPart.cpp
@@ -51,6 +51,7 @@ void ImagPart
 #define EL_ENABLE_DOUBLEDOUBLE
 #define EL_ENABLE_QUADDOUBLE
 #define EL_ENABLE_QUAD
+#define EL_ENABLE_BIGINT
 #define EL_ENABLE_BIGFLOAT
 #include "El/macros/Instantiate.h"
 

--- a/src/blas_like/level1/Kronecker.cpp
+++ b/src/blas_like/level1/Kronecker.cpp
@@ -264,6 +264,7 @@ void Kronecker
 #define EL_ENABLE_DOUBLEDOUBLE
 #define EL_ENABLE_QUADDOUBLE
 #define EL_ENABLE_QUAD
+#define EL_ENABLE_BIGINT
 #define EL_ENABLE_BIGFLOAT
 #include "El/macros/Instantiate.h"
 

--- a/src/blas_like/level1/MakeDiagonalReal.cpp
+++ b/src/blas_like/level1/MakeDiagonalReal.cpp
@@ -51,6 +51,7 @@ void MakeDiagonalReal( AbstractDistMatrix<T>& A, Int offset )
 #define EL_ENABLE_DOUBLEDOUBLE
 #define EL_ENABLE_QUADDOUBLE
 #define EL_ENABLE_QUAD
+#define EL_ENABLE_BIGINT
 #define EL_ENABLE_BIGFLOAT
 #include "El/macros/Instantiate.h"
 

--- a/src/blas_like/level1/MakeHermitian.cpp
+++ b/src/blas_like/level1/MakeHermitian.cpp
@@ -47,6 +47,7 @@ void MakeHermitian( UpperOrLower uplo, DistSparseMatrix<T>& A )
 #define EL_ENABLE_DOUBLEDOUBLE
 #define EL_ENABLE_QUADDOUBLE
 #define EL_ENABLE_QUAD
+#define EL_ENABLE_BIGINT
 #define EL_ENABLE_BIGFLOAT
 #include "El/macros/Instantiate.h"
 

--- a/src/blas_like/level1/MakeReal.cpp
+++ b/src/blas_like/level1/MakeReal.cpp
@@ -41,6 +41,7 @@ void MakeReal( AbstractDistMatrix<T>& A )
 #define EL_ENABLE_DOUBLEDOUBLE
 #define EL_ENABLE_QUADDOUBLE
 #define EL_ENABLE_QUAD
+#define EL_ENABLE_BIGINT
 #define EL_ENABLE_BIGFLOAT
 #include "El/macros/Instantiate.h"
 

--- a/src/blas_like/level1/MakeSubmatrixReal.cpp
+++ b/src/blas_like/level1/MakeSubmatrixReal.cpp
@@ -72,6 +72,7 @@ void MakeSubmatrixReal
 #define EL_ENABLE_DOUBLEDOUBLE
 #define EL_ENABLE_QUADDOUBLE
 #define EL_ENABLE_QUAD
+#define EL_ENABLE_BIGINT
 #define EL_ENABLE_BIGFLOAT
 #include "El/macros/Instantiate.h"
 

--- a/src/blas_like/level1/MakeSymmetric.cpp
+++ b/src/blas_like/level1/MakeSymmetric.cpp
@@ -191,6 +191,7 @@ void MakeSymmetric( UpperOrLower uplo, DistSparseMatrix<T>& A, bool conjugate )
 #define EL_ENABLE_DOUBLEDOUBLE
 #define EL_ENABLE_QUADDOUBLE
 #define EL_ENABLE_QUAD
+#define EL_ENABLE_BIGINT
 #define EL_ENABLE_BIGFLOAT
 #include "El/macros/Instantiate.h"
 

--- a/src/blas_like/level1/MakeTrapezoidal.cpp
+++ b/src/blas_like/level1/MakeTrapezoidal.cpp
@@ -131,6 +131,7 @@ void MakeTrapezoidal( UpperOrLower uplo, DistSparseMatrix<T>& A, Int offset )
 #define EL_ENABLE_DOUBLEDOUBLE
 #define EL_ENABLE_QUADDOUBLE
 #define EL_ENABLE_QUAD
+#define EL_ENABLE_BIGINT
 #define EL_ENABLE_BIGFLOAT
 #include "El/macros/Instantiate.h"
 

--- a/src/blas_like/level1/Max.cpp
+++ b/src/blas_like/level1/Max.cpp
@@ -135,6 +135,7 @@ Real SymmetricMax( UpperOrLower uplo, const AbstractDistMatrix<Real>& A )
 #define EL_ENABLE_DOUBLEDOUBLE
 #define EL_ENABLE_QUADDOUBLE
 #define EL_ENABLE_QUAD
+#define EL_ENABLE_BIGINT
 #define EL_ENABLE_BIGFLOAT
 #include "El/macros/Instantiate.h"
 

--- a/src/blas_like/level1/MaxAbsLoc.cpp
+++ b/src/blas_like/level1/MaxAbsLoc.cpp
@@ -503,6 +503,7 @@ Entry<Base<T>> SymmetricMaxAbsLoc
 #define EL_ENABLE_DOUBLEDOUBLE
 #define EL_ENABLE_QUADDOUBLE
 #define EL_ENABLE_QUAD
+#define EL_ENABLE_BIGINT
 #define EL_ENABLE_BIGFLOAT
 #include "El/macros/Instantiate.h"
 

--- a/src/blas_like/level1/MaxLoc.cpp
+++ b/src/blas_like/level1/MaxLoc.cpp
@@ -333,6 +333,7 @@ SymmetricMaxLoc( UpperOrLower uplo, const AbstractDistMatrix<Real>& A )
 #define EL_ENABLE_DOUBLEDOUBLE
 #define EL_ENABLE_QUADDOUBLE
 #define EL_ENABLE_QUAD
+#define EL_ENABLE_BIGINT
 #define EL_ENABLE_BIGFLOAT
 #include "El/macros/Instantiate.h"
 

--- a/src/blas_like/level1/Min.cpp
+++ b/src/blas_like/level1/Min.cpp
@@ -135,6 +135,7 @@ Real SymmetricMin( UpperOrLower uplo, const AbstractDistMatrix<Real>& A )
 #define EL_ENABLE_DOUBLEDOUBLE
 #define EL_ENABLE_QUADDOUBLE
 #define EL_ENABLE_QUAD
+#define EL_ENABLE_BIGINT
 #define EL_ENABLE_BIGFLOAT
 #include "El/macros/Instantiate.h"
 

--- a/src/blas_like/level1/MinLoc.cpp
+++ b/src/blas_like/level1/MinLoc.cpp
@@ -333,6 +333,7 @@ SymmetricMinLoc( UpperOrLower uplo, const AbstractDistMatrix<Real>& A )
 #define EL_ENABLE_DOUBLEDOUBLE
 #define EL_ENABLE_QUADDOUBLE
 #define EL_ENABLE_QUAD
+#define EL_ENABLE_BIGINT
 #define EL_ENABLE_BIGFLOAT
 #include "El/macros/Instantiate.h"
 

--- a/src/blas_like/level1/RealPart.cpp
+++ b/src/blas_like/level1/RealPart.cpp
@@ -51,6 +51,7 @@ void RealPart
 #define EL_ENABLE_DOUBLEDOUBLE
 #define EL_ENABLE_QUADDOUBLE
 #define EL_ENABLE_QUAD
+#define EL_ENABLE_BIGINT
 #define EL_ENABLE_BIGFLOAT
 #include "El/macros/Instantiate.h"
 

--- a/src/blas_like/level1/Reshape.cpp
+++ b/src/blas_like/level1/Reshape.cpp
@@ -202,6 +202,7 @@ DistSparseMatrix<T> Reshape( Int mNew, Int nNew, const DistSparseMatrix<T>& A )
 #define EL_ENABLE_DOUBLEDOUBLE
 #define EL_ENABLE_QUADDOUBLE
 #define EL_ENABLE_QUAD
+#define EL_ENABLE_BIGINT
 #define EL_ENABLE_BIGFLOAT
 #include "El/macros/Instantiate.h"
 

--- a/src/blas_like/level1/Round.cpp
+++ b/src/blas_like/level1/Round.cpp
@@ -29,6 +29,12 @@ template<>
 void Round( Matrix<Int>& A )
 { }
 
+#ifdef EL_HAVE_MPC
+template<>
+void Round( Matrix<BigInt>& A )
+{ }
+#endif
+
 template<typename T>
 void Round( AbstractDistMatrix<T>& A )
 { Round( A.Matrix() ); }
@@ -45,6 +51,7 @@ void Round( DistMultiVec<T>& A )
 #define EL_ENABLE_DOUBLEDOUBLE
 #define EL_ENABLE_QUADDOUBLE
 #define EL_ENABLE_QUAD
+#define EL_ENABLE_BIGINT
 #define EL_ENABLE_BIGFLOAT
 #include "El/macros/Instantiate.h"
 

--- a/src/blas_like/level1/SetSubmatrix.cpp
+++ b/src/blas_like/level1/SetSubmatrix.cpp
@@ -67,6 +67,7 @@ void SetSubmatrix
 #define EL_ENABLE_DOUBLEDOUBLE
 #define EL_ENABLE_QUADDOUBLE
 #define EL_ENABLE_QUAD
+#define EL_ENABLE_BIGINT
 #define EL_ENABLE_BIGFLOAT
 #include "El/macros/Instantiate.h"
 

--- a/src/blas_like/level1/Swap.cpp
+++ b/src/blas_like/level1/Swap.cpp
@@ -481,6 +481,7 @@ void HermitianSwap
 #define EL_ENABLE_DOUBLEDOUBLE
 #define EL_ENABLE_QUADDOUBLE
 #define EL_ENABLE_QUAD
+#define EL_ENABLE_BIGINT
 #define EL_ENABLE_BIGFLOAT
 #include "El/macros/Instantiate.h"
 

--- a/src/blas_like/level1/Transform2x2.cpp
+++ b/src/blas_like/level1/Transform2x2.cpp
@@ -248,6 +248,7 @@ void Transform2x2Cols
 #define EL_ENABLE_DOUBLEDOUBLE
 #define EL_ENABLE_QUADDOUBLE
 #define EL_ENABLE_QUAD
+#define EL_ENABLE_BIGINT
 #define EL_ENABLE_BIGFLOAT
 #include "El/macros/Instantiate.h"
 

--- a/src/blas_like/level1/TransposeAxpy.cpp
+++ b/src/blas_like/level1/TransposeAxpy.cpp
@@ -191,6 +191,7 @@ void TransposeAxpy
 #define EL_ENABLE_DOUBLEDOUBLE
 #define EL_ENABLE_QUADDOUBLE
 #define EL_ENABLE_QUAD
+#define EL_ENABLE_BIGINT
 #define EL_ENABLE_BIGFLOAT
 #include "El/macros/Instantiate.h"
 

--- a/src/blas_like/level1/TransposeAxpyContract.cpp
+++ b/src/blas_like/level1/TransposeAxpyContract.cpp
@@ -66,6 +66,7 @@ void TransposeAxpyContract
 #define EL_ENABLE_DOUBLEDOUBLE
 #define EL_ENABLE_QUADDOUBLE
 #define EL_ENABLE_QUAD
+#define EL_ENABLE_BIGINT
 #define EL_ENABLE_BIGFLOAT
 #include "El/macros/Instantiate.h"
 

--- a/src/blas_like/level1/Zero.cpp
+++ b/src/blas_like/level1/Zero.cpp
@@ -65,6 +65,7 @@ void Zero( DistMultiVec<T>& X )
 #define EL_ENABLE_DOUBLEDOUBLE
 #define EL_ENABLE_QUADDOUBLE
 #define EL_ENABLE_QUAD
+#define EL_ENABLE_BIGINT
 #define EL_ENABLE_BIGFLOAT
 #include "El/macros/Instantiate.h"
 

--- a/src/blas_like/level2/Gemv.cpp
+++ b/src/blas_like/level2/Gemv.cpp
@@ -271,6 +271,7 @@ void Gemv
 #define EL_ENABLE_DOUBLEDOUBLE
 #define EL_ENABLE_QUADDOUBLE
 #define EL_ENABLE_QUAD
+#define EL_ENABLE_BIGINT
 #define EL_ENABLE_BIGFLOAT
 #include "El/macros/Instantiate.h"
 

--- a/src/blas_like/level2/Ger.cpp
+++ b/src/blas_like/level2/Ger.cpp
@@ -151,6 +151,7 @@ void LocalGer
 #define EL_ENABLE_DOUBLEDOUBLE
 #define EL_ENABLE_QUADDOUBLE
 #define EL_ENABLE_QUAD
+#define EL_ENABLE_BIGINT
 #define EL_ENABLE_BIGFLOAT
 #include "El/macros/Instantiate.h"
 

--- a/src/blas_like/level2/Geru.cpp
+++ b/src/blas_like/level2/Geru.cpp
@@ -139,6 +139,7 @@ void Geru
 #define EL_ENABLE_DOUBLEDOUBLE
 #define EL_ENABLE_QUADDOUBLE
 #define EL_ENABLE_QUAD
+#define EL_ENABLE_BIGINT
 #define EL_ENABLE_BIGFLOAT
 #include "El/macros/Instantiate.h"
 

--- a/src/blas_like/level2/Hemv.cpp
+++ b/src/blas_like/level2/Hemv.cpp
@@ -44,6 +44,7 @@ void Hemv
 #define EL_ENABLE_DOUBLEDOUBLE
 #define EL_ENABLE_QUADDOUBLE
 #define EL_ENABLE_QUAD
+#define EL_ENABLE_BIGINT
 #define EL_ENABLE_BIGFLOAT
 #include "El/macros/Instantiate.h"
 

--- a/src/blas_like/level2/Her.cpp
+++ b/src/blas_like/level2/Her.cpp
@@ -38,6 +38,7 @@ void Her
 #define EL_ENABLE_DOUBLEDOUBLE
 #define EL_ENABLE_QUADDOUBLE
 #define EL_ENABLE_QUAD
+#define EL_ENABLE_BIGINT
 #define EL_ENABLE_BIGFLOAT
 #include "El/macros/Instantiate.h"
 

--- a/src/blas_like/level2/Her2.cpp
+++ b/src/blas_like/level2/Her2.cpp
@@ -41,6 +41,7 @@ void Her2
 #define EL_ENABLE_DOUBLEDOUBLE
 #define EL_ENABLE_QUADDOUBLE
 #define EL_ENABLE_QUAD
+#define EL_ENABLE_BIGINT
 #define EL_ENABLE_BIGFLOAT
 #include "El/macros/Instantiate.h"
 

--- a/src/blas_like/level2/Symv.cpp
+++ b/src/blas_like/level2/Symv.cpp
@@ -336,6 +336,7 @@ void LocalRowAccumulate
 #define EL_ENABLE_DOUBLEDOUBLE
 #define EL_ENABLE_QUADDOUBLE
 #define EL_ENABLE_QUAD
+#define EL_ENABLE_BIGINT
 #define EL_ENABLE_BIGFLOAT
 #include "El/macros/Instantiate.h"
 

--- a/src/blas_like/level2/Syr.cpp
+++ b/src/blas_like/level2/Syr.cpp
@@ -165,6 +165,7 @@ void Syr
 #define EL_ENABLE_DOUBLEDOUBLE
 #define EL_ENABLE_QUADDOUBLE
 #define EL_ENABLE_QUAD
+#define EL_ENABLE_BIGINT
 #define EL_ENABLE_BIGFLOAT
 #include "El/macros/Instantiate.h"
 

--- a/src/blas_like/level2/Syr2.cpp
+++ b/src/blas_like/level2/Syr2.cpp
@@ -303,6 +303,7 @@ void Syr2
 #define EL_ENABLE_DOUBLEDOUBLE
 #define EL_ENABLE_QUADDOUBLE
 #define EL_ENABLE_QUAD
+#define EL_ENABLE_BIGINT
 #define EL_ENABLE_BIGFLOAT
 #include "El/macros/Instantiate.h"
 

--- a/src/blas_like/level2/Trmv.cpp
+++ b/src/blas_like/level2/Trmv.cpp
@@ -45,6 +45,7 @@ void Trmv
 #define EL_ENABLE_DOUBLEDOUBLE
 #define EL_ENABLE_QUADDOUBLE
 #define EL_ENABLE_QUAD
+#define EL_ENABLE_BIGINT
 #define EL_ENABLE_BIGFLOAT
 #include "El/macros/Instantiate.h"
 

--- a/src/blas_like/level2/Trr.cpp
+++ b/src/blas_like/level2/Trr.cpp
@@ -142,6 +142,7 @@ void Trr
 #define EL_ENABLE_DOUBLEDOUBLE
 #define EL_ENABLE_QUADDOUBLE
 #define EL_ENABLE_QUAD
+#define EL_ENABLE_BIGINT
 #define EL_ENABLE_BIGFLOAT
 #include "El/macros/Instantiate.h"
 

--- a/src/blas_like/level2/Trr2.cpp
+++ b/src/blas_like/level2/Trr2.cpp
@@ -154,6 +154,7 @@ void Trr2
 #define EL_ENABLE_DOUBLEDOUBLE
 #define EL_ENABLE_QUADDOUBLE
 #define EL_ENABLE_QUAD
+#define EL_ENABLE_BIGINT
 #define EL_ENABLE_BIGFLOAT
 #include "El/macros/Instantiate.h"
 

--- a/src/blas_like/level3/Gemm.cpp
+++ b/src/blas_like/level3/Gemm.cpp
@@ -289,6 +289,7 @@ void LocalGemm
 #define EL_ENABLE_DOUBLEDOUBLE
 #define EL_ENABLE_QUADDOUBLE
 #define EL_ENABLE_QUAD
+#define EL_ENABLE_BIGINT
 #define EL_ENABLE_BIGFLOAT
 #include "El/macros/Instantiate.h"
 

--- a/src/blas_like/level3/Hemm.cpp
+++ b/src/blas_like/level3/Hemm.cpp
@@ -42,6 +42,7 @@ void Hemm
 #define EL_ENABLE_DOUBLEDOUBLE
 #define EL_ENABLE_QUADDOUBLE
 #define EL_ENABLE_QUAD
+#define EL_ENABLE_BIGINT
 #define EL_ENABLE_BIGFLOAT
 #include "El/macros/Instantiate.h"
 

--- a/src/blas_like/level3/Her2k.cpp
+++ b/src/blas_like/level3/Her2k.cpp
@@ -73,11 +73,10 @@ void Her2k
                   const ElementalMatrix<T>& B, \
     Base<T> beta,       ElementalMatrix<T>& C );
 
-// blas::Her2k not yet supported for Int
-#define EL_NO_INT_PROTO
 #define EL_ENABLE_DOUBLEDOUBLE
 #define EL_ENABLE_QUADDOUBLE
 #define EL_ENABLE_QUAD
+#define EL_ENABLE_BIGINT
 #define EL_ENABLE_BIGFLOAT
 #include "El/macros/Instantiate.h"
 

--- a/src/blas_like/level3/Herk.cpp
+++ b/src/blas_like/level3/Herk.cpp
@@ -123,11 +123,10 @@ void Herk
     Base<T> alpha, const DistSparseMatrix<T>& A, \
                          DistSparseMatrix<T>& C );
 
-// blas::Herk not yet supported for Int
-#define EL_NO_INT_PROTO
 #define EL_ENABLE_DOUBLEDOUBLE
 #define EL_ENABLE_QUADDOUBLE
 #define EL_ENABLE_QUAD
+#define EL_ENABLE_BIGINT
 #define EL_ENABLE_BIGFLOAT
 #include "El/macros/Instantiate.h"
 

--- a/src/blas_like/level3/Multiply.cpp
+++ b/src/blas_like/level3/Multiply.cpp
@@ -697,6 +697,7 @@ void Multiply
 #define EL_ENABLE_DOUBLEDOUBLE
 #define EL_ENABLE_QUADDOUBLE
 #define EL_ENABLE_QUAD
+#define EL_ENABLE_BIGINT
 #define EL_ENABLE_BIGFLOAT
 #include "El/macros/Instantiate.h"
 

--- a/src/blas_like/level3/Symm.cpp
+++ b/src/blas_like/level3/Symm.cpp
@@ -121,6 +121,7 @@ void Symm
 #define EL_ENABLE_DOUBLEDOUBLE
 #define EL_ENABLE_QUADDOUBLE
 #define EL_ENABLE_QUAD
+#define EL_ENABLE_BIGINT
 #define EL_ENABLE_BIGFLOAT
 #include "El/macros/Instantiate.h"
 

--- a/src/blas_like/level3/Syr2k.cpp
+++ b/src/blas_like/level3/Syr2k.cpp
@@ -117,10 +117,10 @@ void Syr2k
     T alpha, const ElementalMatrix<T>& A, const ElementalMatrix<T>& B, \
                    ElementalMatrix<T>& C, bool conjugate );
 
-#define EL_NO_INT_PROTO
 #define EL_ENABLE_DOUBLEDOUBLE
 #define EL_ENABLE_QUADDOUBLE
 #define EL_ENABLE_QUAD
+#define EL_ENABLE_BIGINT
 #define EL_ENABLE_BIGFLOAT
 #include "El/macros/Instantiate.h"
 

--- a/src/blas_like/level3/Syrk.cpp
+++ b/src/blas_like/level3/Syrk.cpp
@@ -294,11 +294,10 @@ void Syrk
     T alpha, const DistSparseMatrix<T>& A, \
                    DistSparseMatrix<T>& C, bool conjugate );
 
-// blas::Syrk is not yet supported for Int
-#define EL_NO_INT_PROTO
 #define EL_ENABLE_DOUBLEDOUBLE
 #define EL_ENABLE_QUADDOUBLE
 #define EL_ENABLE_QUAD
+#define EL_ENABLE_BIGINT
 #define EL_ENABLE_BIGFLOAT
 #include "El/macros/Instantiate.h"
 

--- a/src/blas_like/level3/Trmm.cpp
+++ b/src/blas_like/level3/Trmm.cpp
@@ -118,10 +118,10 @@ void LocalTrmm
     Orientation orientation, UnitOrNonUnit diag, \
     T alpha, const DistMatrix<T,STAR,STAR>& A, ElementalMatrix<T>& B );
 
-#define EL_NO_INT_PROTO
 #define EL_ENABLE_DOUBLEDOUBLE
 #define EL_ENABLE_QUADDOUBLE
 #define EL_ENABLE_QUAD
+#define EL_ENABLE_BIGINT
 #define EL_ENABLE_BIGFLOAT
 #include "El/macros/Instantiate.h"
 

--- a/src/blas_like/level3/Trr2k.cpp
+++ b/src/blas_like/level3/Trr2k.cpp
@@ -141,10 +141,10 @@ void Trr2k
     T beta,  const ElementalMatrix<T>& C, const ElementalMatrix<T>& D, \
     T gamma,       ElementalMatrix<T>& E );
 
-#define EL_NO_INT_PROTO
 #define EL_ENABLE_DOUBLEDOUBLE
 #define EL_ENABLE_QUADDOUBLE
 #define EL_ENABLE_QUAD
+#define EL_ENABLE_BIGINT
 #define EL_ENABLE_BIGFLOAT
 #include "El/macros/Instantiate.h"
 

--- a/src/blas_like/level3/Trrk.cpp
+++ b/src/blas_like/level3/Trrk.cpp
@@ -86,10 +86,10 @@ void Trrk
              const DistMatrix<T,MR,  STAR>& B, \
     T beta,        DistMatrix<T>& C );
 
-#define EL_NO_INT_PROTO
 #define EL_ENABLE_DOUBLEDOUBLE
 #define EL_ENABLE_QUADDOUBLE
 #define EL_ENABLE_QUAD
+#define EL_ENABLE_BIGINT
 #define EL_ENABLE_BIGFLOAT
 #include "El/macros/Instantiate.h"
 

--- a/src/blas_like/level3/Trtrmm.cpp
+++ b/src/blas_like/level3/Trtrmm.cpp
@@ -53,10 +53,10 @@ void Trtrmm( UpperOrLower uplo, DistMatrix<T,STAR,STAR>& A, bool conjugate )
   template void Trtrmm \
   ( UpperOrLower uplo, DistMatrix<T,STAR,STAR>& A, bool conjugate );
 
-#define EL_NO_INT_PROTO
 #define EL_ENABLE_DOUBLEDOUBLE
 #define EL_ENABLE_QUADDOUBLE
 #define EL_ENABLE_QUAD
+#define EL_ENABLE_BIGINT
 #define EL_ENABLE_BIGFLOAT
 #include "El/macros/Instantiate.h"
 

--- a/src/blas_like/level3/TwoSidedTrmm.cpp
+++ b/src/blas_like/level3/TwoSidedTrmm.cpp
@@ -113,10 +113,10 @@ void TwoSidedTrmm
           DistMatrix<T,MC,MR,BLOCK>& A, \
     const DistMatrix<T,MC,MR,BLOCK>& B );
 
-#define EL_NO_INT_PROTO
 #define EL_ENABLE_DOUBLEDOUBLE
 #define EL_ENABLE_QUADDOUBLE
 #define EL_ENABLE_QUAD
+#define EL_ENABLE_BIGINT
 #define EL_ENABLE_BIGFLOAT
 #include "El/macros/Instantiate.h"
 

--- a/src/core/DistMatrix/Abstract.cpp
+++ b/src/core/DistMatrix/Abstract.cpp
@@ -979,6 +979,7 @@ AbstractDistMatrix<T>::ShallowSwap( AbstractDistMatrix<T>& A )
 #define EL_ENABLE_DOUBLEDOUBLE
 #define EL_ENABLE_QUADDOUBLE
 #define EL_ENABLE_QUAD
+#define EL_ENABLE_BIGINT
 #define EL_ENABLE_BIGFLOAT
 #include "El/macros/Instantiate.h"
 

--- a/src/core/DistMatrix/Block.cpp
+++ b/src/core/DistMatrix/Block.cpp
@@ -841,6 +841,7 @@ void AssertConforming2x2
 #define EL_ENABLE_DOUBLEDOUBLE
 #define EL_ENABLE_QUADDOUBLE
 #define EL_ENABLE_QUAD
+#define EL_ENABLE_BIGINT
 #define EL_ENABLE_BIGFLOAT
 #include "El/macros/Instantiate.h"
 

--- a/src/core/DistMatrix/Block/CIRC_CIRC.cpp
+++ b/src/core/DistMatrix/Block/CIRC_CIRC.cpp
@@ -149,6 +149,7 @@ int BDM::PartialUnionRowRank() const EL_NO_EXCEPT
 #define EL_ENABLE_DOUBLEDOUBLE
 #define EL_ENABLE_QUADDOUBLE
 #define EL_ENABLE_QUAD
+#define EL_ENABLE_BIGINT
 #define EL_ENABLE_BIGFLOAT
 #include "El/macros/Instantiate.h"
 

--- a/src/core/DistMatrix/Block/MC_MR.cpp
+++ b/src/core/DistMatrix/Block/MC_MR.cpp
@@ -273,6 +273,7 @@ int BDM::PartialUnionRowRank() const EL_NO_EXCEPT
 #define EL_ENABLE_DOUBLEDOUBLE
 #define EL_ENABLE_QUADDOUBLE
 #define EL_ENABLE_QUAD
+#define EL_ENABLE_BIGINT
 #define EL_ENABLE_BIGFLOAT
 #include "El/macros/Instantiate.h"
 

--- a/src/core/DistMatrix/Block/MC_STAR.cpp
+++ b/src/core/DistMatrix/Block/MC_STAR.cpp
@@ -296,6 +296,7 @@ int BDM::PartialUnionRowRank() const EL_NO_EXCEPT
 #define EL_ENABLE_DOUBLEDOUBLE
 #define EL_ENABLE_QUADDOUBLE
 #define EL_ENABLE_QUAD
+#define EL_ENABLE_BIGINT
 #define EL_ENABLE_BIGFLOAT
 #include "El/macros/Instantiate.h"
 

--- a/src/core/DistMatrix/Block/MD_STAR.cpp
+++ b/src/core/DistMatrix/Block/MD_STAR.cpp
@@ -277,6 +277,7 @@ int BDM::PartialUnionRowRank() const EL_NO_EXCEPT
 #define EL_ENABLE_DOUBLEDOUBLE
 #define EL_ENABLE_QUADDOUBLE
 #define EL_ENABLE_QUAD
+#define EL_ENABLE_BIGINT
 #define EL_ENABLE_BIGFLOAT
 #include "El/macros/Instantiate.h"
 

--- a/src/core/DistMatrix/Block/MR_MC.cpp
+++ b/src/core/DistMatrix/Block/MR_MC.cpp
@@ -271,6 +271,7 @@ int BDM::PartialUnionRowRank() const EL_NO_EXCEPT
 #define EL_ENABLE_DOUBLEDOUBLE
 #define EL_ENABLE_QUADDOUBLE
 #define EL_ENABLE_QUAD
+#define EL_ENABLE_BIGINT
 #define EL_ENABLE_BIGFLOAT
 #include "El/macros/Instantiate.h"
 

--- a/src/core/DistMatrix/Block/MR_STAR.cpp
+++ b/src/core/DistMatrix/Block/MR_STAR.cpp
@@ -291,6 +291,7 @@ int BDM::PartialUnionRowRank() const EL_NO_EXCEPT
 #define EL_ENABLE_DOUBLEDOUBLE
 #define EL_ENABLE_QUADDOUBLE
 #define EL_ENABLE_QUAD
+#define EL_ENABLE_BIGINT
 #define EL_ENABLE_BIGFLOAT
 #include "El/macros/Instantiate.h"
 

--- a/src/core/DistMatrix/Block/STAR_MC.cpp
+++ b/src/core/DistMatrix/Block/STAR_MC.cpp
@@ -288,6 +288,7 @@ int BDM::PartialUnionRowRank() const EL_NO_EXCEPT
 #define EL_ENABLE_DOUBLEDOUBLE
 #define EL_ENABLE_QUADDOUBLE
 #define EL_ENABLE_QUAD
+#define EL_ENABLE_BIGINT
 #define EL_ENABLE_BIGFLOAT
 #include "El/macros/Instantiate.h"
 

--- a/src/core/DistMatrix/Block/STAR_MD.cpp
+++ b/src/core/DistMatrix/Block/STAR_MD.cpp
@@ -277,6 +277,7 @@ int BDM::PartialUnionRowRank() const EL_NO_EXCEPT
 #define EL_ENABLE_DOUBLEDOUBLE
 #define EL_ENABLE_QUADDOUBLE
 #define EL_ENABLE_QUAD
+#define EL_ENABLE_BIGINT
 #define EL_ENABLE_BIGFLOAT
 #include "El/macros/Instantiate.h"
 

--- a/src/core/DistMatrix/Block/STAR_MR.cpp
+++ b/src/core/DistMatrix/Block/STAR_MR.cpp
@@ -303,6 +303,7 @@ int BDM::PartialUnionRowRank() const EL_NO_EXCEPT
 #define EL_ENABLE_DOUBLEDOUBLE
 #define EL_ENABLE_QUADDOUBLE
 #define EL_ENABLE_QUAD
+#define EL_ENABLE_BIGINT
 #define EL_ENABLE_BIGFLOAT
 #include "El/macros/Instantiate.h"
 

--- a/src/core/DistMatrix/Block/STAR_STAR.cpp
+++ b/src/core/DistMatrix/Block/STAR_STAR.cpp
@@ -272,6 +272,7 @@ int BDM::PartialUnionRowRank() const EL_NO_EXCEPT
 #define EL_ENABLE_DOUBLEDOUBLE
 #define EL_ENABLE_QUADDOUBLE
 #define EL_ENABLE_QUAD
+#define EL_ENABLE_BIGINT
 #define EL_ENABLE_BIGFLOAT
 #include "El/macros/Instantiate.h"
 

--- a/src/core/DistMatrix/Block/STAR_VC.cpp
+++ b/src/core/DistMatrix/Block/STAR_VC.cpp
@@ -291,6 +291,7 @@ int BDM::PartialUnionColRank() const EL_NO_EXCEPT
 #define EL_ENABLE_DOUBLEDOUBLE
 #define EL_ENABLE_QUADDOUBLE
 #define EL_ENABLE_QUAD
+#define EL_ENABLE_BIGINT
 #define EL_ENABLE_BIGFLOAT
 #include "El/macros/Instantiate.h"
 

--- a/src/core/DistMatrix/Block/STAR_VR.cpp
+++ b/src/core/DistMatrix/Block/STAR_VR.cpp
@@ -282,6 +282,7 @@ int BDM::PartialUnionColRank() const EL_NO_EXCEPT
 #define EL_ENABLE_DOUBLEDOUBLE
 #define EL_ENABLE_QUADDOUBLE
 #define EL_ENABLE_QUAD
+#define EL_ENABLE_BIGINT
 #define EL_ENABLE_BIGFLOAT
 #include "El/macros/Instantiate.h"
 

--- a/src/core/DistMatrix/Block/VC_STAR.cpp
+++ b/src/core/DistMatrix/Block/VC_STAR.cpp
@@ -291,6 +291,7 @@ int BDM::PartialUnionRowRank() const EL_NO_EXCEPT
 #define EL_ENABLE_DOUBLEDOUBLE
 #define EL_ENABLE_QUADDOUBLE
 #define EL_ENABLE_QUAD
+#define EL_ENABLE_BIGINT
 #define EL_ENABLE_BIGFLOAT
 #include "El/macros/Instantiate.h"
 

--- a/src/core/DistMatrix/Block/VR_STAR.cpp
+++ b/src/core/DistMatrix/Block/VR_STAR.cpp
@@ -287,6 +287,7 @@ int BDM::PartialUnionRowRank() const EL_NO_EXCEPT
 #define EL_ENABLE_DOUBLEDOUBLE
 #define EL_ENABLE_QUADDOUBLE
 #define EL_ENABLE_QUAD
+#define EL_ENABLE_BIGINT
 #define EL_ENABLE_BIGFLOAT
 #include "El/macros/Instantiate.h"
 

--- a/src/core/DistMatrix/Element.cpp
+++ b/src/core/DistMatrix/Element.cpp
@@ -821,6 +821,7 @@ ElementalMatrix<T>::ShallowSwap( ElementalMatrix<T>& A )
 #define EL_ENABLE_DOUBLEDOUBLE
 #define EL_ENABLE_QUADDOUBLE
 #define EL_ENABLE_QUAD
+#define EL_ENABLE_BIGINT
 #define EL_ENABLE_BIGFLOAT
 #include "El/macros/Instantiate.h"
 

--- a/src/core/DistMatrix/Element/CIRC_CIRC.cpp
+++ b/src/core/DistMatrix/Element/CIRC_CIRC.cpp
@@ -143,6 +143,7 @@ int DM::PartialUnionRowRank() const EL_NO_EXCEPT
 #define EL_ENABLE_DOUBLEDOUBLE
 #define EL_ENABLE_QUADDOUBLE
 #define EL_ENABLE_QUAD
+#define EL_ENABLE_BIGINT
 #define EL_ENABLE_BIGFLOAT
 #include "El/macros/Instantiate.h"
 

--- a/src/core/DistMatrix/Element/MC_MR.cpp
+++ b/src/core/DistMatrix/Element/MC_MR.cpp
@@ -277,6 +277,7 @@ int DM::PartialUnionRowRank() const EL_NO_EXCEPT
 #define EL_ENABLE_DOUBLEDOUBLE
 #define EL_ENABLE_QUADDOUBLE
 #define EL_ENABLE_QUAD
+#define EL_ENABLE_BIGINT
 #define EL_ENABLE_BIGFLOAT
 #include "El/macros/Instantiate.h"
 

--- a/src/core/DistMatrix/Element/MC_STAR.cpp
+++ b/src/core/DistMatrix/Element/MC_STAR.cpp
@@ -304,6 +304,7 @@ int DM::PartialUnionRowRank() const EL_NO_EXCEPT
 #define EL_ENABLE_DOUBLEDOUBLE
 #define EL_ENABLE_QUADDOUBLE
 #define EL_ENABLE_QUAD
+#define EL_ENABLE_BIGINT
 #define EL_ENABLE_BIGFLOAT
 #include "El/macros/Instantiate.h"
 

--- a/src/core/DistMatrix/Element/MD_STAR.cpp
+++ b/src/core/DistMatrix/Element/MD_STAR.cpp
@@ -272,6 +272,7 @@ int DM::PartialUnionRowRank() const EL_NO_EXCEPT
 #define EL_ENABLE_DOUBLEDOUBLE
 #define EL_ENABLE_QUADDOUBLE
 #define EL_ENABLE_QUAD
+#define EL_ENABLE_BIGINT
 #define EL_ENABLE_BIGFLOAT
 #include "El/macros/Instantiate.h"
 

--- a/src/core/DistMatrix/Element/MR_MC.cpp
+++ b/src/core/DistMatrix/Element/MR_MC.cpp
@@ -273,6 +273,7 @@ int DM::PartialUnionRowRank() const EL_NO_EXCEPT
 #define EL_ENABLE_DOUBLEDOUBLE
 #define EL_ENABLE_QUADDOUBLE
 #define EL_ENABLE_QUAD
+#define EL_ENABLE_BIGINT
 #define EL_ENABLE_BIGFLOAT
 #include "El/macros/Instantiate.h"
 

--- a/src/core/DistMatrix/Element/MR_STAR.cpp
+++ b/src/core/DistMatrix/Element/MR_STAR.cpp
@@ -302,6 +302,7 @@ int DM::PartialUnionRowRank() const EL_NO_EXCEPT
 #define EL_ENABLE_DOUBLEDOUBLE
 #define EL_ENABLE_QUADDOUBLE
 #define EL_ENABLE_QUAD
+#define EL_ENABLE_BIGINT
 #define EL_ENABLE_BIGFLOAT
 #include "El/macros/Instantiate.h"
 

--- a/src/core/DistMatrix/Element/STAR_MC.cpp
+++ b/src/core/DistMatrix/Element/STAR_MC.cpp
@@ -296,6 +296,7 @@ int DM::PartialUnionRowRank() const EL_NO_EXCEPT
 #define EL_ENABLE_DOUBLEDOUBLE
 #define EL_ENABLE_QUADDOUBLE
 #define EL_ENABLE_QUAD
+#define EL_ENABLE_BIGINT
 #define EL_ENABLE_BIGFLOAT
 #include "El/macros/Instantiate.h"
 

--- a/src/core/DistMatrix/Element/STAR_MD.cpp
+++ b/src/core/DistMatrix/Element/STAR_MD.cpp
@@ -272,6 +272,7 @@ int DM::PartialUnionRowRank() const EL_NO_EXCEPT
 #define EL_ENABLE_DOUBLEDOUBLE
 #define EL_ENABLE_QUADDOUBLE
 #define EL_ENABLE_QUAD
+#define EL_ENABLE_BIGINT
 #define EL_ENABLE_BIGFLOAT
 #include "El/macros/Instantiate.h"
 

--- a/src/core/DistMatrix/Element/STAR_MR.cpp
+++ b/src/core/DistMatrix/Element/STAR_MR.cpp
@@ -307,6 +307,7 @@ int DM::PartialUnionRowRank() const EL_NO_EXCEPT
 #define EL_ENABLE_DOUBLEDOUBLE
 #define EL_ENABLE_QUADDOUBLE
 #define EL_ENABLE_QUAD
+#define EL_ENABLE_BIGINT
 #define EL_ENABLE_BIGFLOAT
 #include "El/macros/Instantiate.h"
 

--- a/src/core/DistMatrix/Element/STAR_STAR.cpp
+++ b/src/core/DistMatrix/Element/STAR_STAR.cpp
@@ -256,6 +256,7 @@ int DM::PartialUnionRowRank() const EL_NO_EXCEPT
 #define EL_ENABLE_DOUBLEDOUBLE
 #define EL_ENABLE_QUADDOUBLE
 #define EL_ENABLE_QUAD
+#define EL_ENABLE_BIGINT
 #define EL_ENABLE_BIGFLOAT
 #include "El/macros/Instantiate.h"
 

--- a/src/core/DistMatrix/Element/STAR_VC.cpp
+++ b/src/core/DistMatrix/Element/STAR_VC.cpp
@@ -282,6 +282,7 @@ int DM::PartialUnionColRank() const EL_NO_EXCEPT
 #define EL_ENABLE_DOUBLEDOUBLE
 #define EL_ENABLE_QUADDOUBLE
 #define EL_ENABLE_QUAD
+#define EL_ENABLE_BIGINT
 #define EL_ENABLE_BIGFLOAT
 #include "El/macros/Instantiate.h"
 

--- a/src/core/DistMatrix/Element/STAR_VR.cpp
+++ b/src/core/DistMatrix/Element/STAR_VR.cpp
@@ -273,6 +273,7 @@ int DM::PartialUnionColRank() const EL_NO_EXCEPT
 #define EL_ENABLE_DOUBLEDOUBLE
 #define EL_ENABLE_QUADDOUBLE
 #define EL_ENABLE_QUAD
+#define EL_ENABLE_BIGINT
 #define EL_ENABLE_BIGFLOAT
 #include "El/macros/Instantiate.h"
 

--- a/src/core/DistMatrix/Element/VC_STAR.cpp
+++ b/src/core/DistMatrix/Element/VC_STAR.cpp
@@ -282,6 +282,7 @@ int DM::PartialUnionRowRank() const EL_NO_EXCEPT
 #define EL_ENABLE_DOUBLEDOUBLE
 #define EL_ENABLE_QUADDOUBLE
 #define EL_ENABLE_QUAD
+#define EL_ENABLE_BIGINT
 #define EL_ENABLE_BIGFLOAT
 #include "El/macros/Instantiate.h"
 

--- a/src/core/DistMatrix/Element/VR_STAR.cpp
+++ b/src/core/DistMatrix/Element/VR_STAR.cpp
@@ -278,6 +278,7 @@ int DM::PartialUnionRowRank() const EL_NO_EXCEPT
 #define EL_ENABLE_DOUBLEDOUBLE
 #define EL_ENABLE_QUADDOUBLE
 #define EL_ENABLE_QUAD
+#define EL_ENABLE_BIGINT
 #define EL_ENABLE_BIGFLOAT
 #include "El/macros/Instantiate.h"
 

--- a/src/core/DistMultiVec.cpp
+++ b/src/core/DistMultiVec.cpp
@@ -417,6 +417,7 @@ void DistMultiVec<T>::ProcessQueues()
 #define EL_ENABLE_DOUBLEDOUBLE
 #define EL_ENABLE_QUADDOUBLE
 #define EL_ENABLE_QUAD
+#define EL_ENABLE_BIGINT
 #define EL_ENABLE_BIGFLOAT
 #include "El/macros/Instantiate.h"
 

--- a/src/core/DistSparseMatrix.cpp
+++ b/src/core/DistSparseMatrix.cpp
@@ -854,6 +854,7 @@ bool DistSparseMatrix<T>::CompareEntries( const Entry<T>& a, const Entry<T>& b )
 #define EL_ENABLE_DOUBLEDOUBLE
 #define EL_ENABLE_QUADDOUBLE
 #define EL_ENABLE_QUAD
+#define EL_ENABLE_BIGINT
 #define EL_ENABLE_BIGFLOAT
 #include "El/macros/Instantiate.h"
 

--- a/src/core/Element.cpp
+++ b/src/core/Element.cpp
@@ -156,6 +156,15 @@ Quad Abs( const Complex<Quad>& alphaPre ) EL_NO_EXCEPT
 
 #ifdef EL_HAVE_MPC
 template<>
+BigInt Abs( const BigInt& alpha ) EL_NO_EXCEPT
+{
+    BigInt absAlpha;
+    absAlpha.SetMinBits( alpha.NumBits() );
+    mpz_abs( absAlpha.Pointer(), alpha.LockedPointer() );
+    return absAlpha;
+}
+
+template<>
 BigFloat Abs( const BigFloat& alpha ) EL_NO_EXCEPT
 {
     BigFloat absAlpha;
@@ -177,6 +186,18 @@ Quad SafeAbs( const Complex<Quad>& alpha ) EL_NO_EXCEPT
 #endif
 
 #ifdef EL_HAVE_MPC
+BigInt Sgn( const BigInt& alpha, bool symmetric ) EL_NO_EXCEPT
+{
+    const int numBits = alpha.NumBits();
+    const int result = mpz_cmp_si( alpha.LockedPointer(), 0 );
+    if( result < 0 )
+        return BigInt(-1,numBits);
+    else if( result > 0 || !symmetric )
+        return BigInt(1,numBits);
+    else
+        return BigInt(0,numBits);
+}
+
 BigFloat Sgn( const BigFloat& alpha, bool symmetric ) EL_NO_EXCEPT
 {
     mpfr_prec_t prec = alpha.Precision();
@@ -234,23 +255,20 @@ BigFloat Exp( const BigFloat& alpha ) EL_NO_EXCEPT
 #ifdef EL_HAVE_QD
 template<>
 DoubleDouble Pow( const DoubleDouble& alpha, const DoubleDouble& beta )
-EL_NO_EXCEPT
 { return pow(alpha,beta); }
 
 template<>
 QuadDouble Pow( const QuadDouble& alpha, const QuadDouble& beta )
-EL_NO_EXCEPT
 { return pow(alpha,beta); }
 #endif
 
 #ifdef EL_HAVE_QUAD
 template<>
-Quad Pow( const Quad& alpha, const Quad& beta ) EL_NO_EXCEPT
+Quad Pow( const Quad& alpha, const Quad& beta )
 { return powq(alpha,beta); }
 
 template<>
-Complex<Quad> Pow
-( const Complex<Quad>& alphaPre, const Complex<Quad>& betaPre ) EL_NO_EXCEPT
+Complex<Quad> Pow( const Complex<Quad>& alphaPre, const Complex<Quad>& betaPre )
 {
     __complex128 alpha, beta;
     __real__(alpha) = alphaPre.real();
@@ -263,8 +281,7 @@ Complex<Quad> Pow
 }
 
 template<>
-Complex<Quad> Pow
-( const Complex<Quad>& alphaPre, const Quad& betaPre ) EL_NO_EXCEPT
+Complex<Quad> Pow( const Complex<Quad>& alphaPre, const Quad& betaPre )
 {
     __complex128 alpha, beta;
     __real__(alpha) = alphaPre.real();
@@ -279,7 +296,32 @@ Complex<Quad> Pow
 
 #ifdef EL_HAVE_MPC
 template<>
-BigFloat Pow( const BigFloat& alpha, const BigFloat& beta ) EL_NO_EXCEPT
+BigInt Pow( const BigInt& alpha, const BigInt& beta )
+{
+    BigInt gamma;
+    gamma.SetMinBits( alpha.NumBits() );
+    mpz_pow_ui( gamma.Pointer(), alpha.LockedPointer(), (unsigned long)(beta) );
+    return gamma;
+}
+
+BigInt Pow( const BigInt& alpha, const unsigned& beta )
+{
+    BigInt gamma;
+    gamma.SetMinBits( alpha.NumBits() );
+    mpz_pow_ui( gamma.Pointer(), alpha.LockedPointer(), beta );
+    return gamma;
+}
+
+BigInt Pow( const BigInt& alpha, const unsigned long& beta )
+{
+    BigInt gamma;
+    gamma.SetMinBits( alpha.NumBits() );
+    mpz_pow_ui( gamma.Pointer(), alpha.LockedPointer(), beta );
+    return gamma;
+}
+
+template<>
+BigFloat Pow( const BigFloat& alpha, const BigFloat& beta )
 {
     BigFloat gamma;
     gamma.SetPrecision( alpha.Precision() );
@@ -897,6 +939,8 @@ Quad Round( const Quad& alpha ) { return rintq(alpha); }
 #endif
 #ifdef EL_HAVE_MPC
 template<>
+BigInt Round( const BigInt& alpha ) { return alpha; }
+template<>
 BigFloat Round( const BigFloat& alpha )
 { 
     BigFloat alphaRound;
@@ -920,6 +964,8 @@ template<> Quad Ceil( const Quad& alpha ) { return ceilq(alpha); }
 #endif
 #ifdef EL_HAVE_MPC
 template<>
+BigInt Ceil( const BigInt& alpha ) { return alpha; }
+template<>
 BigFloat Ceil( const BigFloat& alpha )
 {
     BigFloat alphaCeil;
@@ -942,6 +988,8 @@ template<> QuadDouble Floor( const QuadDouble& alpha )
 template<> Quad Floor( const Quad& alpha ) { return floorq(alpha); }
 #endif
 #ifdef EL_HAVE_MPC
+template<>
+BigInt Floor( const BigInt& alpha ) { return alpha; }
 template<> BigFloat Floor( const BigFloat& alpha )
 {
     BigFloat alphaFloor;

--- a/src/core/FlamePart/Merge.cpp
+++ b/src/core/FlamePart/Merge.cpp
@@ -448,6 +448,7 @@ DistMatrix<T,U,V> LockedMerge2x2
 #define EL_ENABLE_DOUBLEDOUBLE
 #define EL_ENABLE_QUADDOUBLE
 #define EL_ENABLE_QUAD
+#define EL_ENABLE_BIGINT
 #define EL_ENABLE_BIGFLOAT
 #include "El/macros/Instantiate.h"
 

--- a/src/core/FlamePart/Partition.cpp
+++ b/src/core/FlamePart/Partition.cpp
@@ -606,6 +606,7 @@ void LockedPartitionUpDiagonal
 #define EL_ENABLE_DOUBLEDOUBLE
 #define EL_ENABLE_QUADDOUBLE
 #define EL_ENABLE_QUAD
+#define EL_ENABLE_BIGINT
 #define EL_ENABLE_BIGFLOAT
 #include "El/macros/Instantiate.h"
 

--- a/src/core/FlamePart/Repartition.cpp
+++ b/src/core/FlamePart/Repartition.cpp
@@ -536,6 +536,7 @@ void LockedRepartitionDownDiagonal
 #define EL_ENABLE_DOUBLEDOUBLE
 #define EL_ENABLE_QUADDOUBLE
 #define EL_ENABLE_QUAD
+#define EL_ENABLE_BIGINT
 #define EL_ENABLE_BIGFLOAT
 #include "El/macros/Instantiate.h"
 

--- a/src/core/FlamePart/SlidePartition.cpp
+++ b/src/core/FlamePart/SlidePartition.cpp
@@ -518,6 +518,7 @@ void SlideLockedPartitionDownDiagonal
 #define EL_ENABLE_DOUBLEDOUBLE
 #define EL_ENABLE_QUADDOUBLE
 #define EL_ENABLE_QUAD
+#define EL_ENABLE_BIGINT
 #define EL_ENABLE_BIGFLOAT
 #include "El/macros/Instantiate.h"
 

--- a/src/core/Matrix.cpp
+++ b/src/core/Matrix.cpp
@@ -697,6 +697,7 @@ void Matrix<T>::Resize_( Int height, Int width, Int ldim )
 #define EL_ENABLE_DOUBLEDOUBLE
 #define EL_ENABLE_QUADDOUBLE
 #define EL_ENABLE_QUAD
+#define EL_ENABLE_BIGINT
 #define EL_ENABLE_BIGFLOAT
 #include "El/macros/Instantiate.h"
 

--- a/src/core/Memory.cpp
+++ b/src/core/Memory.cpp
@@ -121,6 +121,7 @@ void Memory<G>::Empty()
 #define EL_ENABLE_DOUBLEDOUBLE
 #define EL_ENABLE_QUADDOUBLE
 #define EL_ENABLE_QUAD
+#define EL_ENABLE_BIGINT
 #define EL_ENABLE_BIGFLOAT
 #include "El/macros/Instantiate.h"
 

--- a/src/core/Serialize.cpp
+++ b/src/core/Serialize.cpp
@@ -12,11 +12,31 @@
 
 namespace El {
 
+byte* Serialize( Int n, const BigInt* x, byte* buf )
+{
+    DEBUG_ONLY(CSE cse("Serialize"))
+    for( Int j=0; j<n; ++j )
+        buf = x[j].Serialize( buf );
+    return buf;
+}
+
 byte* Serialize( Int n, const BigFloat* x, byte* buf )
 {
     DEBUG_ONLY(CSE cse("Serialize"))
     for( Int j=0; j<n; ++j )
         buf = x[j].Serialize( buf );
+    return buf;
+}
+
+byte* Serialize( Int n, const ValueInt<BigInt>* x, byte* buf )
+{
+    DEBUG_ONLY(CSE cse("Serialize"))
+    for( Int j=0; j<n; ++j )
+    {
+        buf = x[j].value.Serialize( buf );
+        std::memcpy( buf, &x[j].index, sizeof(Int) );
+        buf += sizeof(Int);
+    }
     return buf;
 }
 
@@ -28,6 +48,20 @@ byte* Serialize( Int n, const ValueInt<BigFloat>* x, byte* buf )
         buf = x[j].value.Serialize( buf );
         std::memcpy( buf, &x[j].index, sizeof(Int) );
         buf += sizeof(Int);
+    }
+    return buf;
+}
+
+byte* Serialize( Int n, const Entry<BigInt>* x, byte* buf )
+{
+    DEBUG_ONLY(CSE cse("Serialize"))
+    for( Int k=0; k<n; ++k )
+    {
+        std::memcpy( buf, &x[k].i, sizeof(Int) );
+        buf += sizeof(Int);
+        std::memcpy( buf, &x[k].j, sizeof(Int) );
+        buf += sizeof(Int);
+        buf = x[k].value.Serialize( buf );
     }
     return buf;
 }
@@ -46,6 +80,18 @@ byte* Serialize( Int n, const Entry<BigFloat>* x, byte* buf )
     return buf;
 }
 
+void ReserveSerialized( Int n, const BigInt* x, std::vector<byte>& buf )
+{
+    DEBUG_ONLY(CSE cse("ReserveSerialized"))
+    if( n == 0 )
+    {
+        buf.resize(0);
+        return;
+    }
+    const auto packedSize = x[0].SerializedSize();
+    buf.resize( n*packedSize );
+}
+
 void ReserveSerialized( Int n, const BigFloat* x, std::vector<byte>& buf )
 {
     DEBUG_ONLY(CSE cse("ReserveSerialized"))
@@ -55,6 +101,19 @@ void ReserveSerialized( Int n, const BigFloat* x, std::vector<byte>& buf )
         return;
     }
     const auto packedSize = x[0].SerializedSize();
+    buf.resize( n*packedSize );
+}
+
+void ReserveSerialized
+( Int n, const ValueInt<BigInt>* x, std::vector<byte>& buf )
+{
+    DEBUG_ONLY(CSE cse("ReserveSerialized"))
+    if( n == 0 )
+    {
+        buf.resize(0);
+        return;
+    }
+    const auto packedSize = x[0].value.SerializedSize() + sizeof(Int);
     buf.resize( n*packedSize );
 }
 
@@ -72,6 +131,19 @@ void ReserveSerialized
 }
 
 void ReserveSerialized
+( Int n, const Entry<BigInt>* x, std::vector<byte>& buf )
+{
+    DEBUG_ONLY(CSE cse("ReserveSerialized"))
+    if( n == 0 )
+    {
+        buf.resize(0);
+        return;
+    }
+    const auto packedSize = x[0].value.SerializedSize() + 2*sizeof(Int);
+    buf.resize( n*packedSize );
+}
+
+void ReserveSerialized
 ( Int n, const Entry<BigFloat>* x, std::vector<byte>& buf )
 {
     DEBUG_ONLY(CSE cse("ReserveSerialized"))
@@ -84,7 +156,21 @@ void ReserveSerialized
     buf.resize( n*packedSize );
 }
 
+void Serialize( Int n, const BigInt* x, std::vector<byte>& buf )
+{
+    DEBUG_ONLY(CSE cse("Serialize"))
+    ReserveSerialized( n, x, buf );
+    Serialize( n, x, buf.data() );
+}
+
 void Serialize( Int n, const BigFloat* x, std::vector<byte>& buf )
+{
+    DEBUG_ONLY(CSE cse("Serialize"))
+    ReserveSerialized( n, x, buf );
+    Serialize( n, x, buf.data() );
+}
+
+void Serialize( Int n, const ValueInt<BigInt>* x, std::vector<byte>& buf )
 {
     DEBUG_ONLY(CSE cse("Serialize"))
     ReserveSerialized( n, x, buf );
@@ -98,6 +184,13 @@ void Serialize( Int n, const ValueInt<BigFloat>* x, std::vector<byte>& buf )
     Serialize( n, x, buf.data() );
 }
 
+void Serialize( Int n, const Entry<BigInt>* x, std::vector<byte>& buf )
+{
+    DEBUG_ONLY(CSE cse("Serialize"))
+    ReserveSerialized( n, x, buf );
+    Serialize( n, x, buf.data() );
+}
+
 void Serialize( Int n, const Entry<BigFloat>* x, std::vector<byte>& buf )
 {
     DEBUG_ONLY(CSE cse("Serialize"))
@@ -105,11 +198,31 @@ void Serialize( Int n, const Entry<BigFloat>* x, std::vector<byte>& buf )
     Serialize( n, x, buf.data() );
 }
 
+byte* Deserialize( Int n, byte* buf, BigInt* x )
+{
+    DEBUG_ONLY(CSE cse("Deserialize [BigInt]"))
+    for( Int j=0; j<n; ++j )
+        buf = x[j].Deserialize( buf );
+    return buf;
+}
+
 byte* Deserialize( Int n, byte* buf, BigFloat* x )
 {
     DEBUG_ONLY(CSE cse("Deserialize [BigFloat]"))
     for( Int j=0; j<n; ++j )
         buf = x[j].Deserialize( buf );
+    return buf;
+}
+
+byte* Deserialize( Int n, byte* buf, ValueInt<BigInt>* x )
+{
+    DEBUG_ONLY(CSE cse("Deserialize [ValueInt<BigInt>]"))
+    for( Int j=0; j<n; ++j )
+    {
+        buf = x[j].value.Deserialize( buf );
+        std::memcpy( &x[j].index, buf, sizeof(Int) );
+        buf += sizeof(Int);
+    }
     return buf;
 }
 
@@ -121,6 +234,20 @@ byte* Deserialize( Int n, byte* buf, ValueInt<BigFloat>* x )
         buf = x[j].value.Deserialize( buf );
         std::memcpy( &x[j].index, buf, sizeof(Int) );
         buf += sizeof(Int);
+    }
+    return buf;
+}
+
+byte* Deserialize( Int n, byte* buf, Entry<BigInt>* x )
+{
+    DEBUG_ONLY(CSE cse("Deserialize [Entry<BigInt>]"))
+    for( Int k=0; k<n; ++k )
+    {
+        std::memcpy( &x[k].i, buf, sizeof(Int) );
+        buf += sizeof(Int);
+        std::memcpy( &x[k].j, buf, sizeof(Int) );
+        buf += sizeof(Int);
+        buf = x[k].value.Deserialize( buf );
     }
     return buf;
 }
@@ -139,11 +266,31 @@ byte* Deserialize( Int n, byte* buf, Entry<BigFloat>* x )
     return buf;
 }
 
+const byte* Deserialize( Int n, const byte* buf, BigInt* x )
+{
+    DEBUG_ONLY(CSE cse("Deserialize [BigInt]"))
+    for( Int j=0; j<n; ++j )
+        buf = x[j].Deserialize( buf );
+    return buf;
+}
+
 const byte* Deserialize( Int n, const byte* buf, BigFloat* x )
 {
     DEBUG_ONLY(CSE cse("Deserialize [BigFloat]"))
     for( Int j=0; j<n; ++j )
         buf = x[j].Deserialize( buf );
+    return buf;
+}
+
+const byte* Deserialize( Int n, const byte* buf, ValueInt<BigInt>* x )
+{
+    DEBUG_ONLY(CSE cse("Deserialize [ValueInt<BigInt>]"))
+    for( Int j=0; j<n; ++j )
+    {
+        buf = x[j].value.Deserialize( buf );
+        std::memcpy( &x[j].index, buf, sizeof(Int) );
+        buf += sizeof(Int);
+    }
     return buf;
 }
 
@@ -155,6 +302,20 @@ const byte* Deserialize( Int n, const byte* buf, ValueInt<BigFloat>* x )
         buf = x[j].value.Deserialize( buf );
         std::memcpy( &x[j].index, buf, sizeof(Int) );
         buf += sizeof(Int);
+    }
+    return buf;
+}
+
+const byte* Deserialize( Int n, const byte* buf, Entry<BigInt>* x )
+{
+    DEBUG_ONLY(CSE cse("Deserialize [Entry<BigInt>]"))
+    for( Int k=0; k<n; ++k )
+    {
+        std::memcpy( &x[k].i, buf, sizeof(Int) );
+        buf += sizeof(Int);
+        std::memcpy( &x[k].j, buf, sizeof(Int) );
+        buf += sizeof(Int);
+        buf = x[k].value.Deserialize( buf );
     }
     return buf;
 }
@@ -171,6 +332,19 @@ const byte* Deserialize( Int n, const byte* buf, Entry<BigFloat>* x )
         buf = x[k].value.Deserialize( buf );
     }
     return buf;
+}
+
+void Deserialize( Int n, const std::vector<byte>& buf, BigInt* x )
+{
+    Deserialize( n, buf.data(), x ); 
+}
+void Deserialize( Int n, const std::vector<byte>& buf, ValueInt<BigInt>* x )
+{
+    Deserialize( n, buf.data(), x );
+}
+void Deserialize( Int n, const std::vector<byte>& buf, Entry<BigInt>* x )
+{
+    Deserialize( n, buf.data(), x );
 }
 
 void Deserialize( Int n, const std::vector<byte>& buf, BigFloat* x )

--- a/src/core/SparseMatrix.cpp
+++ b/src/core/SparseMatrix.cpp
@@ -451,6 +451,7 @@ void SparseMatrix<T>::AssertConsistent() const
 #define EL_ENABLE_DOUBLEDOUBLE
 #define EL_ENABLE_QUADDOUBLE
 #define EL_ENABLE_QUAD
+#define EL_ENABLE_BIGINT
 #define EL_ENABLE_BIGFLOAT
 #include "El/macros/Instantiate.h"
 

--- a/src/core/global.cpp
+++ b/src/core/global.cpp
@@ -66,9 +66,11 @@ Int localSymvQuadBlocksize = 64;
 Int localSymvComplexQuadBlocksize = 64;
 #endif
 #ifdef EL_HAVE_MPC
+Int localSymvBigIntBlocksize = 64;
 Int localSymvBigFloatBlocksize = 64;
 #endif
 
+Int localTrr2kIntBlocksize = 64;
 Int localTrr2kFloatBlocksize = 64;
 Int localTrr2kDoubleBlocksize = 64;
 Int localTrr2kComplexFloatBlocksize = 64;
@@ -82,9 +84,11 @@ Int localTrr2kQuadBlocksize = 64;
 Int localTrr2kComplexQuadBlocksize = 64;
 #endif
 #ifdef EL_HAVE_MPC
+Int localTrr2kBigIntBlocksize = 64;
 Int localTrr2kBigFloatBlocksize = 64;
 #endif
 
+Int localTrrkIntBlocksize = 64;
 Int localTrrkFloatBlocksize = 64;
 Int localTrrkDoubleBlocksize = 64;
 Int localTrrkComplexFloatBlocksize = 64;
@@ -98,6 +102,7 @@ Int localTrrkQuadBlocksize = 64;
 Int localTrrkComplexQuadBlocksize = 64;
 #endif
 #ifdef EL_HAVE_MPC
+Int localTrrkBigIntBlocksize = 64;
 Int localTrrkBigFloatBlocksize = 64;
 #endif
 
@@ -408,6 +413,7 @@ void Initialize( int& argc, char**& argv )
     ::generator.seed( seed );
     srand( seed );
 #ifdef EL_HAVE_MPC
+    mpc::SetMinIntBits( 256 );
     mpc::SetPrecision( 256 );
     gmp_randinit_default( ::gmpRandState );
     gmp_randseed_ui( ::gmpRandState, seed );
@@ -754,6 +760,10 @@ void SetLocalSymvBlocksize<Complex<Quad>>( Int blocksize )
 
 #ifdef EL_HAVE_MPC
 template<>
+void SetLocalSymvBlocksize<BigInt>( Int blocksize )
+{ ::localSymvBigIntBlocksize = blocksize; }
+
+template<>
 void SetLocalSymvBlocksize<BigFloat>( Int blocksize )
 { ::localSymvBigFloatBlocksize = blocksize; }
 #endif
@@ -799,9 +809,16 @@ Int LocalSymvBlocksize<Complex<Quad>>()
 
 #ifdef EL_HAVE_MPC
 template<>
+Int LocalSymvBlocksize<BigInt>()
+{ return ::localSymvBigIntBlocksize; }
+template<>
 Int LocalSymvBlocksize<BigFloat>()
 { return ::localSymvBigFloatBlocksize; }
 #endif
+
+template<>
+void SetLocalTrr2kBlocksize<Int>( Int blocksize )
+{ ::localTrr2kIntBlocksize = blocksize; }
 
 template<>
 void SetLocalTrr2kBlocksize<float>( Int blocksize )
@@ -841,9 +858,16 @@ void SetLocalTrr2kBlocksize<Complex<Quad>>( Int blocksize )
 
 #ifdef EL_HAVE_MPC
 template<>
+void SetLocalTrr2kBlocksize<BigInt>( Int blocksize )
+{ ::localTrr2kBigIntBlocksize = blocksize; }
+template<>
 void SetLocalTrr2kBlocksize<BigFloat>( Int blocksize )
 { ::localTrr2kBigFloatBlocksize = blocksize; }
 #endif
+
+template<>
+Int LocalTrr2kBlocksize<Int>()
+{ return ::localTrr2kIntBlocksize; }
 
 template<>
 Int LocalTrr2kBlocksize<float>()
@@ -883,9 +907,16 @@ Int LocalTrr2kBlocksize<Complex<Quad>>()
 
 #ifdef EL_HAVE_MPC
 template<>
+Int LocalTrr2kBlocksize<BigInt>()
+{ return ::localTrr2kBigIntBlocksize; }
+template<>
 Int LocalTrr2kBlocksize<BigFloat>()
 { return ::localTrr2kBigFloatBlocksize; }
 #endif
+
+template<>
+void SetLocalTrrkBlocksize<Int>( Int blocksize )
+{ ::localTrrkIntBlocksize = blocksize; }
 
 template<>
 void SetLocalTrrkBlocksize<float>( Int blocksize )
@@ -925,9 +956,16 @@ void SetLocalTrrkBlocksize<Complex<Quad>>( Int blocksize )
 
 #ifdef EL_HAVE_MPC
 template<>
+void SetLocalTrrkBlocksize<BigInt>( Int blocksize )
+{ ::localTrrkBigIntBlocksize = blocksize; }
+template<>
 void SetLocalTrrkBlocksize<BigFloat>( Int blocksize )
 { ::localTrrkBigFloatBlocksize = blocksize; }
 #endif
+
+template<>
+Int LocalTrrkBlocksize<Int>()
+{ return ::localTrrkIntBlocksize; }
 
 template<>
 Int LocalTrrkBlocksize<float>()
@@ -966,6 +1004,9 @@ Int LocalTrrkBlocksize<Complex<Quad>>()
 #endif
 
 #ifdef EL_HAVE_MPC
+template<>
+Int LocalTrrkBlocksize<BigInt>()
+{ return ::localTrrkBigIntBlocksize; }
 template<>
 Int LocalTrrkBlocksize<BigFloat>()
 { return ::localTrrkBigFloatBlocksize; }

--- a/src/core/imports/blas.cpp
+++ b/src/core/imports/blas.cpp
@@ -17,11 +17,13 @@ extern "C" {
 // Level 1 BLAS
 // ============
 void EL_BLAS(saxpy)
-( const BlasInt* n, const float* alpha, const float* x, const BlasInt* incx,
-                                              float* y, const BlasInt* incy );
+( const BlasInt* n, const float* alpha,
+  const float* x, const BlasInt* incx,
+  float* y, const BlasInt* incy );
 void EL_BLAS(daxpy)
-( const BlasInt* n, const double* alpha, const double* x, const BlasInt* incx,
-                                               double* y, const BlasInt* incy );
+( const BlasInt* n, const double* alpha,
+  const double* x, const BlasInt* incx,
+        double* y, const BlasInt* incy );
 void EL_BLAS(caxpy)
 ( const BlasInt* n, const scomplex* alpha,
   const scomplex* x, const BlasInt* incx,
@@ -32,24 +34,30 @@ void EL_BLAS(zaxpy)
         dcomplex* y, const BlasInt* incy );
 
 void EL_BLAS(scopy)
-( const BlasInt* n, const float* x, const BlasInt* incx,
-                          float* y, const BlasInt* incy );
+( const BlasInt* n,
+  const float* x, const BlasInt* incx,
+        float* y, const BlasInt* incy );
 void EL_BLAS(dcopy)
-( const BlasInt* n, const double* x, const BlasInt* incx,
-                          double* y, const BlasInt* incy );
+( const BlasInt* n,
+  const double* x, const BlasInt* incx,
+        double* y, const BlasInt* incy );
 void EL_BLAS(ccopy)
-( const BlasInt* n, const scomplex* x, const BlasInt* incx,
-                          scomplex* y, const BlasInt* incy );
+( const BlasInt* n,
+  const scomplex* x, const BlasInt* incx,
+        scomplex* y, const BlasInt* incy );
 void EL_BLAS(zcopy)
-( const BlasInt* n, const dcomplex* x, const BlasInt* incx,
-                          dcomplex* y, const BlasInt* incy );
+( const BlasInt* n,
+  const dcomplex* x, const BlasInt* incx,
+        dcomplex* y, const BlasInt* incy );
 
 float EL_BLAS(sdot)
-( const BlasInt* n, const float* x, const BlasInt* incx,
-                    const float* y, const BlasInt* incy );
+( const BlasInt* n,
+  const float* x, const BlasInt* incx,
+  const float* y, const BlasInt* incy );
 double EL_BLAS(ddot)
-( const BlasInt* n, const double* x, const BlasInt* incx,
-                    const double* y, const BlasInt* incy );
+( const BlasInt* n,
+  const double* x, const BlasInt* incx,
+  const double* y, const BlasInt* incy );
 // To avoid the compatibility issue, we simply handroll our own complex dots
 float  EL_BLAS(snrm2) 
 ( const BlasInt* n, const float   * x, const BlasInt* incx );
@@ -575,6 +583,10 @@ template void Axpy
 #endif
 #ifdef EL_HAVE_MPC
 template void Axpy
+( BlasInt n, BigInt alpha, 
+  const BigInt* x, BlasInt incx,
+        BigInt* y, BlasInt incy );
+template void Axpy
 ( BlasInt n, BigFloat alpha, 
   const BigFloat* x, BlasInt incx,
         BigFloat* y, BlasInt incy );
@@ -635,6 +647,10 @@ template void Copy
         Complex<Quad>* y, BlasInt incy );
 #endif
 #ifdef EL_HAVE_MPC
+template void Copy
+( BlasInt n,
+  const BigInt* x, BlasInt incx, 
+        BigInt* y, BlasInt incy );
 template void Copy
 ( BlasInt n,
   const BigFloat* x, BlasInt incx, 
@@ -710,6 +726,10 @@ template Complex<Quad> Dot
   const Complex<Quad>* y, BlasInt incy );
 #endif
 #ifdef EL_HAVE_MPC
+template BigInt Dot
+( BlasInt n,
+  const BigInt* x, BlasInt incx, 
+  const BigInt* y, BlasInt incy );
 template BigFloat Dot
 ( BlasInt n,
   const BigFloat* x, BlasInt incx, 
@@ -772,6 +792,10 @@ template Complex<Quad> Dotu
   const Complex<Quad>* y, BlasInt incy );
 #endif
 #ifdef EL_HAVE_MPC
+template BigInt Dotu
+( BlasInt n,
+  const BigInt* x, BlasInt incx, 
+  const BigInt* y, BlasInt incy );
 template BigFloat Dotu
 ( BlasInt n,
   const BigFloat* x, BlasInt incx, 
@@ -840,6 +864,7 @@ template BlasInt MaxInd( BlasInt n, const Quad* x, BlasInt incx );
 template BlasInt MaxInd( BlasInt n, const Complex<Quad>* x, BlasInt incx );
 #endif
 #ifdef EL_HAVE_MPC
+template BlasInt MaxInd( BlasInt n, const BigInt* x, BlasInt incx );
 template BlasInt MaxInd( BlasInt n, const BigFloat* x, BlasInt incx );
 #endif
 
@@ -1045,6 +1070,8 @@ template void Scal
 #endif
 #ifdef EL_HAVE_MPC
 template void Scal
+( BlasInt n, BigInt alpha, BigInt* x, BlasInt incx );
+template void Scal
 ( BlasInt n, BigFloat alpha, BigFloat* x, BlasInt incx );
 #endif
 
@@ -1092,6 +1119,7 @@ template Quad Nrm1( BlasInt n, const Quad* x, BlasInt incx );
 template Quad Nrm1( BlasInt n, const Complex<Quad>* x, BlasInt incx );
 #endif
 #ifdef EL_HAVE_MPC
+template BigInt Nrm1( BlasInt n, const BigInt* x, BlasInt incx );
 template BigFloat Nrm1( BlasInt n, const BigFloat* x, BlasInt incx );
 #endif
 
@@ -1123,6 +1151,8 @@ template void Swap
 ( BlasInt n, Complex<Quad>* x, BlasInt incx, Complex<Quad>* y, BlasInt incy );
 #endif
 #ifdef EL_HAVE_MPC
+template void Swap
+( BlasInt n, BigInt* x, BlasInt incx, BigInt* y, BlasInt incy );
 template void Swap
 ( BlasInt n, BigFloat* x, BlasInt incx, BigFloat* y, BlasInt incy );
 #endif
@@ -1217,6 +1247,11 @@ template void Gemv
 #ifdef EL_HAVE_MPC
 template void Gemv
 ( char trans, BlasInt m, BlasInt n, 
+  BigInt alpha, const BigInt* A, BlasInt ALDim,
+                const BigInt* x, BlasInt incx, 
+  BigInt beta,        BigInt* y, BlasInt incy );
+template void Gemv
+( char trans, BlasInt m, BlasInt n, 
   BigFloat alpha, const BigFloat* A, BlasInt ALDim,
                   const BigFloat* x, BlasInt incx, 
   BigFloat beta,        BigFloat* y, BlasInt incy );
@@ -1303,6 +1338,11 @@ template void Ger
 #ifdef EL_HAVE_MPC
 template void Ger
 ( BlasInt m, BlasInt n, 
+  BigInt alpha, const BigInt* x, BlasInt incx, 
+                const BigInt* y, BlasInt incy, 
+                      BigInt* A, BlasInt ALDim );
+template void Ger
+( BlasInt m, BlasInt n, 
   BigFloat alpha, const BigFloat* x, BlasInt incx, 
                   const BigFloat* y, BlasInt incy, 
                         BigFloat* A, BlasInt ALDim );
@@ -1383,6 +1423,12 @@ template void Geru
         Complex<Quad>* A, BlasInt ALDim );
 #endif
 #ifdef EL_HAVE_MPC
+template void Geru
+( BlasInt m, BlasInt n, 
+  BigInt alpha,
+  const BigInt* x, BlasInt incx, 
+  const BigInt* y, BlasInt incy, 
+        BigInt* A, BlasInt ALDim );
 template void Geru
 ( BlasInt m, BlasInt n, 
   BigFloat alpha,
@@ -1501,6 +1547,11 @@ template void Hemv
 #ifdef EL_HAVE_MPC
 template void Hemv
 ( char uplo, BlasInt m, 
+  BigInt alpha, const BigInt* A, BlasInt ALDim, 
+                const BigInt* x, BlasInt incx, 
+  BigInt beta,        BigInt* y, BlasInt incy );
+template void Hemv
+( char uplo, BlasInt m, 
   BigFloat alpha, const BigFloat* A, BlasInt ALDim, 
                   const BigFloat* x, BlasInt incx, 
   BigFloat beta,        BigFloat* y, BlasInt incy );
@@ -1579,6 +1630,10 @@ template void Her
 #ifdef EL_HAVE_MPC
 template void Her
 ( char uplo, BlasInt m, 
+  BigInt alpha, const BigInt* x, BlasInt incx,
+                      BigInt* A, BlasInt ALDim );
+template void Her
+( char uplo, BlasInt m, 
   BigFloat alpha, const BigFloat* x, BlasInt incx,
                         BigFloat* A, BlasInt ALDim );
 #endif
@@ -1655,6 +1710,11 @@ template void Her2
                              Complex<Quad>* A, BlasInt ALDim );
 #endif
 #ifdef EL_HAVE_MPC
+template void Her2
+( char uplo, BlasInt m, 
+  BigInt alpha, const BigInt* x, BlasInt incx, 
+                const BigInt* y, BlasInt incy, 
+                      BigInt* A, BlasInt ALDim );
 template void Her2
 ( char uplo, BlasInt m, 
   BigFloat alpha, const BigFloat* x, BlasInt incx, 
@@ -1768,6 +1828,11 @@ template void Symv
 #ifdef EL_HAVE_MPC
 template void Symv
 ( char uplo, BlasInt m, 
+  BigInt alpha, const BigInt* A, BlasInt ALDim, 
+                const BigInt* x, BlasInt incx, 
+  BigInt beta,        BigInt* y, BlasInt incy );
+template void Symv
+( char uplo, BlasInt m, 
   BigFloat alpha, const BigFloat* A, BlasInt ALDim, 
                   const BigFloat* x, BlasInt incx, 
   BigFloat beta,        BigFloat* y, BlasInt incy );
@@ -1851,6 +1916,10 @@ template void Syr
                              Complex<Quad>* A, BlasInt ALDim );
 #endif
 #ifdef EL_HAVE_MPC
+template void Syr
+( char uplo, BlasInt m, 
+  BigInt alpha, const BigInt* x, BlasInt incx,
+                      BigInt* A, BlasInt ALDim );
 template void Syr
 ( char uplo, BlasInt m, 
   BigFloat alpha, const BigFloat* x, BlasInt incx,
@@ -1937,6 +2006,11 @@ template void Syr2
                              Complex<Quad>* A, BlasInt ALDim );
 #endif
 #ifdef EL_HAVE_MPC
+template void Syr2
+( char uplo, BlasInt m, 
+  BigInt alpha, const BigInt* x, BlasInt incx, 
+                const BigInt* y, BlasInt incy, 
+                      BigInt* A, BlasInt ALDim );
 template void Syr2
 ( char uplo, BlasInt m, 
   BigFloat alpha, const BigFloat* x, BlasInt incx, 
@@ -2105,6 +2179,10 @@ template void Trmv
         Complex<Quad>* x, BlasInt incx );
 #endif
 #ifdef EL_HAVE_MPC
+template void Trmv
+( char uplo, char trans, char diag, BlasInt m,
+  const BigInt* A, BlasInt ALDim,
+        BigInt* x, BlasInt incx );
 template void Trmv
 ( char uplo, char trans, char diag, BlasInt m,
   const BigFloat* A, BlasInt ALDim,
@@ -2449,6 +2527,12 @@ template void Gemm
 template void Gemm
 ( char transA, char transB,
   BlasInt m, BlasInt n, BlasInt k, 
+  BigInt alpha, const BigInt* A, BlasInt ALDim,
+                const BigInt* B, BlasInt BLDim,
+  BigInt beta,        BigInt* C, BlasInt CLDim );
+template void Gemm
+( char transA, char transB,
+  BlasInt m, BlasInt n, BlasInt k, 
   BigFloat alpha, const BigFloat* A, BlasInt ALDim,
                   const BigFloat* B, BlasInt BLDim,
   BigFloat beta,        BigFloat* C, BlasInt CLDim );
@@ -2730,6 +2814,11 @@ template void Hemm
 #ifdef EL_HAVE_MPC
 template void Hemm
 ( char side, char uplo, BlasInt m, BlasInt n,
+  BigInt alpha, const BigInt* A, BlasInt ALDim, 
+                const BigInt* B, BlasInt BLDim,
+  BigInt beta,        BigInt* C, BlasInt CLDim );
+template void Hemm
+( char side, char uplo, BlasInt m, BlasInt n,
   BigFloat alpha, const BigFloat* A, BlasInt ALDim, 
                   const BigFloat* B, BlasInt BLDim,
   BigFloat beta,        BigFloat* C, BlasInt CLDim );
@@ -2886,6 +2975,12 @@ template void Her2k
 template void Her2k
 ( char uplo, char trans,
   BlasInt n, BlasInt k, 
+  BigInt alpha, const BigInt* A, BlasInt ALDim, 
+                const BigInt* B, BlasInt BLDim,
+  BigInt beta,        BigInt* C, BlasInt CLDim );
+template void Her2k
+( char uplo, char trans,
+  BlasInt n, BlasInt k, 
   BigFloat alpha, const BigFloat* A, BlasInt ALDim, 
                   const BigFloat* B, BlasInt BLDim,
   BigFloat beta,        BigFloat* C, BlasInt CLDim );
@@ -3030,6 +3125,11 @@ template void Herk
   Quad beta,        Complex<Quad>* C, BlasInt CLDim );
 #endif
 #ifdef EL_HAVE_MPC
+template void Herk
+( char uplo, char trans,
+  BlasInt n, BlasInt k, 
+  BigInt alpha, const BigInt* A, BlasInt ALDim, 
+  BigInt beta,        BigInt* C, BlasInt CLDim );
 template void Herk
 ( char uplo, char trans,
   BlasInt n, BlasInt k, 
@@ -3193,6 +3293,11 @@ template void Symm
 #ifdef EL_HAVE_MPC
 template void Symm
 ( char side, char uplo, BlasInt m, BlasInt n,
+  BigInt alpha, const BigInt* A, BlasInt ALDim, 
+                const BigInt* B, BlasInt BLDim,
+  BigInt beta,        BigInt* C, BlasInt CLDim );
+template void Symm
+( char side, char uplo, BlasInt m, BlasInt n,
   BigFloat alpha, const BigFloat* A, BlasInt ALDim, 
                   const BigFloat* B, BlasInt BLDim,
   BigFloat beta,        BigFloat* C, BlasInt CLDim );
@@ -3344,6 +3449,12 @@ template void Syr2k
 template void Syr2k
 ( char uplo, char trans,
   BlasInt n, BlasInt k, 
+  BigInt alpha, const BigInt* A, BlasInt ALDim, 
+                const BigInt* B, BlasInt BLDim,
+  BigInt beta,        BigInt* C, BlasInt CLDim );
+template void Syr2k
+( char uplo, char trans,
+  BlasInt n, BlasInt k, 
   BigFloat alpha, const BigFloat* A, BlasInt ALDim, 
                   const BigFloat* B, BlasInt BLDim,
   BigFloat beta,        BigFloat* C, BlasInt CLDim );
@@ -3485,6 +3596,11 @@ template void Syrk
 template void Syrk
 ( char uplo, char trans,
   BlasInt n, BlasInt k, 
+  BigInt alpha, const BigInt* A, BlasInt ALDim, 
+  BigInt beta,        BigInt* C, BlasInt CLDim );
+template void Syrk
+( char uplo, char trans,
+  BlasInt n, BlasInt k, 
   BigFloat alpha, const BigFloat* A, BlasInt ALDim, 
   BigFloat beta,        BigFloat* C, BlasInt CLDim );
 #endif
@@ -3608,6 +3724,11 @@ void Trmm
         }
     }
 }
+template void Trmm
+( char side, char uplo, char trans, char unit,
+  BlasInt m, BlasInt n,
+  Int alpha, const Int* A, BlasInt ALDim,
+                   Int* B, BlasInt BLDim );
 #ifdef EL_HAVE_QD
 template void Trmm
 ( char side, char uplo, char trans, char unit,
@@ -3633,6 +3754,11 @@ template void Trmm
                              Complex<Quad>* B, BlasInt BLDim );
 #endif
 #ifdef EL_HAVE_MPC
+template void Trmm
+( char side, char uplo, char trans, char unit,
+  BlasInt m, BlasInt n,
+  BigInt alpha, const BigInt* A, BlasInt ALDim,
+                      BigInt* B, BlasInt BLDim );
 template void Trmm
 ( char side, char uplo, char trans, char unit,
   BlasInt m, BlasInt n,

--- a/src/core/imports/lapack.cpp
+++ b/src/core/imports/lapack.cpp
@@ -563,6 +563,9 @@ template void Copy
 #ifdef EL_HAVE_MPC
 template void Copy
 ( char uplo, BlasInt m, BlasInt n, 
+  const BigInt* A, BlasInt lda, BigInt* B, BlasInt ldb );
+template void Copy
+( char uplo, BlasInt m, BlasInt n, 
   const BigFloat* A, BlasInt lda, BigFloat* B, BlasInt ldb );
 #endif
 

--- a/src/core/imports/mkl.cpp
+++ b/src/core/imports/mkl.cpp
@@ -300,6 +300,11 @@ template void omatcopy
 #ifdef EL_HAVE_MPC
 template void omatcopy
 ( Orientation orientation, BlasInt m, BlasInt n,
+  BigInt alpha,
+  const BigInt* A, BlasInt lda,
+        BigInt* B, BlasInt ldb );
+template void omatcopy
+( Orientation orientation, BlasInt m, BlasInt n,
   BigFloat alpha,
   const BigFloat* A, BlasInt lda,
         BigFloat* B, BlasInt ldb );
@@ -422,6 +427,11 @@ template void omatcopy
 #ifdef EL_HAVE_MPC
 template void omatcopy
 ( Orientation orientation, BlasInt m, BlasInt n,
+  BigInt alpha,
+  const BigInt* A, BlasInt lda, BlasInt stridea,
+        BigInt* B, BlasInt ldb, BlasInt strideb );
+template void omatcopy
+( Orientation orientation, BlasInt m, BlasInt n,
   BigFloat alpha,
   const BigFloat* A, BlasInt lda, BlasInt stridea,
         BigFloat* B, BlasInt ldb, BlasInt strideb );
@@ -501,6 +511,9 @@ template void imatcopy
   Complex<Quad> alpha, Complex<Quad>* A, BlasInt lda, BlasInt ldb );
 #endif
 #ifdef EL_HAVE_MPC
+template void imatcopy
+( Orientation orientation, BlasInt m, BlasInt n,
+  BigInt alpha, BigInt* A, BlasInt lda, BlasInt ldb );
 template void imatcopy
 ( Orientation orientation, BlasInt m, BlasInt n,
   BigFloat alpha, BigFloat* A, BlasInt lda, BlasInt ldb );

--- a/src/core/imports/mpc.cpp
+++ b/src/core/imports/mpc.cpp
@@ -12,6 +12,7 @@
 namespace {
 
 size_t numLimbs;
+int numIntLimbs;
 
 } // anonymous namespace
 
@@ -37,6 +38,26 @@ void SetPrecision( mpfr_prec_t prec )
     mpi::CreateBigFloatFamily();
     previouslySet = true;
 }
+
+void SetMinIntBits( int numBits )
+{ 
+    static bool previouslySet = false;
+    const int numIntLimbsNew = (numBits+(GMP_NUMB_BITS-1)) / GMP_NUMB_BITS;
+    if( previouslySet && ::numIntLimbs == numIntLimbsNew ) 
+        return;
+
+    if( previouslySet )
+        mpi::DestroyBigIntFamily();
+    ::numIntLimbs = numIntLimbsNew;
+    mpi::CreateBigIntFamily();
+    previouslySet = true;
+}
+
+int NumIntBits()
+{ return ::numIntLimbs*GMP_NUMB_BITS; }
+
+int NumIntLimbs()
+{ return ::numIntLimbs; }
 
 mpfr_rnd_t RoundingMode()
 { return mpfr_get_default_rounding_mode(); }

--- a/src/core/imports/mpc/BigFloat.cpp
+++ b/src/core/imports/mpc/BigFloat.cpp
@@ -60,6 +60,14 @@ BigFloat::BigFloat( const BigFloat& a, mpfr_prec_t prec )
     )
 }
 
+BigFloat::BigFloat( const BigInt& a, mpfr_prec_t prec )
+{
+    DEBUG_ONLY(CSE cse("BigFloat::BigFloat [BigInt]"))
+    numLimbs_ = (prec-1) / GMP_NUMB_BITS + 1;
+    mpfr_init2( Pointer(), prec );
+    mpfr_set_z( Pointer(), a.LockedPointer(), mpc::RoundingMode() ); 
+}
+
 BigFloat::BigFloat( const unsigned& a, mpfr_prec_t prec )
 {
     DEBUG_ONLY(CSE cse("BigFloat::BigFloat [unsigned]"))
@@ -239,6 +247,13 @@ BigFloat& BigFloat::operator=( const BigFloat& a )
     return *this;
 }
 
+BigFloat& BigFloat::operator=( const BigInt& a )
+{
+    DEBUG_ONLY(CSE cse("BigFloat::operator= [BigInt]"))
+    mpfr_set_z( Pointer(), a.LockedPointer(), mpc::RoundingMode() );
+    return *this;
+}
+
 BigFloat& BigFloat::operator=( const unsigned& a )
 {
     DEBUG_ONLY(CSE cse("BigFloat::operator= [unsigned]"))
@@ -370,10 +385,45 @@ BigFloat& BigFloat::operator=( BigFloat&& a )
     return *this;
 }
 
+BigFloat& BigFloat::operator+=( const unsigned& a )
+{
+    DEBUG_ONLY(CSE cse("BigFloat::operator+= [unsigned]"))
+    mpfr_add_ui( Pointer(), Pointer(), a, mpc::RoundingMode() );
+    return *this;
+}
+
+BigFloat& BigFloat::operator+=( const unsigned long& a )
+{
+    DEBUG_ONLY(CSE cse("BigFloat::operator+= [unsigned long]"))
+    mpfr_add_ui( Pointer(), Pointer(), a, mpc::RoundingMode() );
+    return *this;
+}
+
+BigFloat& BigFloat::operator+=( const int& a )
+{
+    DEBUG_ONLY(CSE cse("BigFloat::operator+= [int]"))
+    mpfr_add_si( Pointer(), Pointer(), a, mpc::RoundingMode() );
+    return *this;
+}
+
+BigFloat& BigFloat::operator+=( const long int& a )
+{
+    DEBUG_ONLY(CSE cse("BigFloat::operator+= [long int]"))
+    mpfr_add_si( Pointer(), Pointer(), a, mpc::RoundingMode() );
+    return *this;
+}
+
 BigFloat& BigFloat::operator+=( const double& a )
 {
     DEBUG_ONLY(CSE cse("BigFloat::operator+= [double]"))
     mpfr_add_d( Pointer(), Pointer(), a, mpc::RoundingMode() );
+    return *this;
+}
+
+BigFloat& BigFloat::operator+=( const BigInt& a )
+{
+    DEBUG_ONLY(CSE cse("BigFloat::operator+= [BigInt]"))
+    mpfr_add_z( Pointer(), Pointer(), a.LockedPointer(), mpc::RoundingMode() );
     return *this;
 }
 
@@ -384,10 +434,45 @@ BigFloat& BigFloat::operator+=( const BigFloat& a )
     return *this;
 }
 
+BigFloat& BigFloat::operator-=( const unsigned& a )
+{
+    DEBUG_ONLY(CSE cse("BigFloat::operator-= [unsigned]"))
+    mpfr_sub_ui( Pointer(), Pointer(), a, mpc::RoundingMode() );
+    return *this;
+}
+
+BigFloat& BigFloat::operator-=( const unsigned long& a )
+{
+    DEBUG_ONLY(CSE cse("BigFloat::operator-= [unsigned long]"))
+    mpfr_sub_ui( Pointer(), Pointer(), a, mpc::RoundingMode() );
+    return *this;
+}
+
+BigFloat& BigFloat::operator-=( const int& a )
+{
+    DEBUG_ONLY(CSE cse("BigFloat::operator-= [int]"))
+    mpfr_sub_si( Pointer(), Pointer(), a, mpc::RoundingMode() );
+    return *this;
+}
+
+BigFloat& BigFloat::operator-=( const long int& a )
+{
+    DEBUG_ONLY(CSE cse("BigFloat::operator-= [long int]"))
+    mpfr_sub_si( Pointer(), Pointer(), a, mpc::RoundingMode() );
+    return *this;
+}
+
 BigFloat& BigFloat::operator-=( const double& a )
 {
     DEBUG_ONLY(CSE cse("BigFloat::operator-= [double]"))
     mpfr_sub_d( Pointer(), Pointer(), a, mpc::RoundingMode() );
+    return *this;
+}
+
+BigFloat& BigFloat::operator-=( const BigInt& a )
+{
+    DEBUG_ONLY(CSE cse("BigFloat::operator-= [BigInt]"))
+    mpfr_sub_z( Pointer(), Pointer(), a.LockedPointer(), mpc::RoundingMode() );
     return *this;
 }
 
@@ -398,10 +483,45 @@ BigFloat& BigFloat::operator-=( const BigFloat& a )
     return *this;
 }
 
+BigFloat& BigFloat::operator*=( const unsigned& a )
+{
+    DEBUG_ONLY(CSE cse("BigFloat::operator*= [unsigned]"))
+    mpfr_mul_ui( Pointer(), Pointer(), a, mpc::RoundingMode() );
+    return *this;
+}
+
+BigFloat& BigFloat::operator*=( const unsigned long& a )
+{
+    DEBUG_ONLY(CSE cse("BigFloat::operator*= [unsigned long]"))
+    mpfr_mul_ui( Pointer(), Pointer(), a, mpc::RoundingMode() );
+    return *this;
+}
+
+BigFloat& BigFloat::operator*=( const int& a )
+{
+    DEBUG_ONLY(CSE cse("BigFloat::operator*= [int]"))
+    mpfr_mul_si( Pointer(), Pointer(), a, mpc::RoundingMode() );
+    return *this;
+}
+
+BigFloat& BigFloat::operator*=( const long int& a )
+{
+    DEBUG_ONLY(CSE cse("BigFloat::operator*= [long int]"))
+    mpfr_mul_si( Pointer(), Pointer(), a, mpc::RoundingMode() );
+    return *this;
+}
+
 BigFloat& BigFloat::operator*=( const double& a )
 {
     DEBUG_ONLY(CSE cse("BigFloat::operator*= [double]"))
     mpfr_mul_d( Pointer(), Pointer(), a, mpc::RoundingMode() );
+    return *this;
+}
+
+BigFloat& BigFloat::operator*=( const BigInt& a )
+{
+    DEBUG_ONLY(CSE cse("BigFloat::operator*= [BigInt]"))
+    mpfr_mul_z( Pointer(), Pointer(), a.LockedPointer(), mpc::RoundingMode() );
     return *this;
 }
 
@@ -412,10 +532,45 @@ BigFloat& BigFloat::operator*=( const BigFloat& a )
     return *this;
 }
 
+BigFloat& BigFloat::operator/=( const unsigned& a )
+{
+    DEBUG_ONLY(CSE cse("BigFloat::operator/= [unsigned]"))
+    mpfr_div_ui( Pointer(), Pointer(), a, mpc::RoundingMode() );
+    return *this;
+}
+
+BigFloat& BigFloat::operator/=( const unsigned long& a )
+{
+    DEBUG_ONLY(CSE cse("BigFloat::operator/= [unsigned long]"))
+    mpfr_div_ui( Pointer(), Pointer(), a, mpc::RoundingMode() );
+    return *this;
+}
+
+BigFloat& BigFloat::operator/=( const int& a )
+{
+    DEBUG_ONLY(CSE cse("BigFloat::operator/= [int]"))
+    mpfr_div_si( Pointer(), Pointer(), a, mpc::RoundingMode() );
+    return *this;
+}
+
+BigFloat& BigFloat::operator/=( const long int& a )
+{
+    DEBUG_ONLY(CSE cse("BigFloat::operator/= [long int]"))
+    mpfr_div_si( Pointer(), Pointer(), a, mpc::RoundingMode() );
+    return *this;
+}
+
 BigFloat& BigFloat::operator/=( const double& a )
 {
     DEBUG_ONLY(CSE cse("BigFloat::operator/= [double]"))
     mpfr_div_d( Pointer(), Pointer(), a, mpc::RoundingMode() );
+    return *this;
+}
+
+BigFloat& BigFloat::operator/=( const BigInt& a )
+{
+    DEBUG_ONLY(CSE cse("BigFloat::operator/= [BigInt]"))
+    mpfr_div_z( Pointer(), Pointer(), a.LockedPointer(), mpc::RoundingMode() );
     return *this;
 }
 
@@ -593,10 +748,17 @@ BigFloat::operator Quad() const
 }
 #endif
 
+BigFloat::operator BigInt() const
+{
+    DEBUG_ONLY(CSE cse("BigFloat::operator BigInt"))
+    BigInt alpha;
+    mpfr_get_z( alpha.Pointer(), LockedPointer(), mpc::RoundingMode() );
+    return alpha;
+}
+
 size_t BigFloat::SerializedSize() const
 {
     DEBUG_ONLY(CSE cse("BigFloat::SerializedSize"))
-    // TODO: Decide whether alignments need to be considered.
     return sizeof(mpfr_prec_t)+
            sizeof(mpfr_sign_t)+
            sizeof(mpfr_exp_t)+
@@ -610,7 +772,6 @@ byte* BigFloat::Serialize( byte* buf ) const
     //       they are known a priori (as long as the user does not fiddle
     //       with SetPrecision)
     // 
-    // TODO: Decide whether alignments need to be considered.
 
     std::memcpy( buf, &mpfrFloat_->_mpfr_prec, sizeof(mpfr_prec_t) );
     buf += sizeof(mpfr_prec_t);
@@ -619,7 +780,6 @@ byte* BigFloat::Serialize( byte* buf ) const
     std::memcpy( buf, &mpfrFloat_->_mpfr_exp, sizeof(mpfr_exp_t) );
     buf += sizeof(mpfr_exp_t);
 
-    // TODO: Avoid this integer computation
     std::memcpy( buf, mpfrFloat_->_mpfr_d, numLimbs_*sizeof(mp_limb_t) );
     buf += numLimbs_*sizeof(mp_limb_t);
 

--- a/src/core/imports/mpc/BigInt.cpp
+++ b/src/core/imports/mpc/BigInt.cpp
@@ -1,0 +1,730 @@
+/*
+   Copyright (c) 2009-2015, Jack Poulson
+   All rights reserved.
+
+   This file is part of Elemental and is under the BSD 2-Clause License, 
+   which can be found in the LICENSE file in the root directory, or at 
+   http://opensource.org/licenses/BSD-2-Clause
+*/
+#include "El.hpp"
+#ifdef EL_HAVE_MPC
+
+namespace El {
+
+mpz_ptr BigInt::Pointer()
+{ return mpzInt_; }
+
+mpz_srcptr BigInt::LockedPointer() const
+{ return mpzInt_; }
+
+void BigInt::SetMinBits( int minBits )
+{
+    mpz_realloc2( mpzInt_, minBits );
+}
+
+void BigInt::SetNumLimbs( int numLimbs )
+{
+    const int prec = numLimbs*GMP_NUMB_BITS;
+    mpz_realloc2( mpzInt_, prec );
+}
+
+int BigInt::NumLimbs() const
+{ return mpzInt_->_mp_size; }
+
+int BigInt::NumBits() const
+{ return mpzInt_->_mp_size*GMP_NUMB_BITS; }
+
+BigInt::BigInt()
+{
+    DEBUG_ONLY(CSE cse("BigInt::BigInt [default]"))
+    int numBits = mpc::NumIntBits();
+    mpz_init2( Pointer(), numBits );
+}
+
+// Copy constructors
+// -----------------
+BigInt::BigInt( const BigInt& a, int numBits )
+{
+    DEBUG_ONLY(CSE cse("BigInt::BigInt [BigInt]"))
+    if( &a != this )
+    {
+        mpz_init2( mpzInt_, numBits );
+        mpz_set( mpzInt_, a.mpzInt_ );
+    }
+    DEBUG_ONLY(
+    else
+        LogicError("Tried to construct BigInt with itself");
+    )
+}
+
+BigInt::BigInt( const unsigned& a, int numBits )
+{
+    DEBUG_ONLY(CSE cse("BigInt::BigInt [unsigned]"))
+    mpz_init2( Pointer(), numBits );
+    mpz_set_ui( Pointer(), a );
+}
+
+BigInt::BigInt( const unsigned long& a, int numBits )
+{
+    DEBUG_ONLY(CSE cse("BigInt::BigInt [unsigned long]"))
+    mpz_init2( Pointer(), numBits );
+    mpz_set_ui( Pointer(), a );
+}
+
+BigInt::BigInt( const unsigned long long& a, int numBits )
+{
+    DEBUG_ONLY(CSE cse("BigInt::BigInt [unsigned long long]"))
+    mpz_init2( Pointer(), numBits );
+    const size_t count = 1;
+    const int order = 1;  // most-significant first
+    const size_t size = sizeof(a);
+    const int endian = 0; // native endianness 
+    const size_t nails = 0; // do not skip any bits
+    mpz_import( Pointer(), count, order, size, endian, nails, &a );
+}
+
+BigInt::BigInt( const int& a, int numBits )
+{
+    DEBUG_ONLY(CSE cse("BigInt::BigInt [int]"))
+    mpz_init2( Pointer(), numBits );
+    mpz_set_si( Pointer(), a );
+}
+
+BigInt::BigInt( const long int& a, int numBits )
+{
+    DEBUG_ONLY(CSE cse("BigInt::BigInt [long int]"))
+    mpz_init2( Pointer(), numBits );
+    mpz_set_si( Pointer(), a );
+}
+
+BigInt::BigInt( const long long int& a, int numBits )
+{
+    DEBUG_ONLY(CSE cse("BigInt::BigInt [long long int]"))
+    mpz_init2( Pointer(), numBits );
+    const size_t count = 1;
+    const int order = 1;  // most-significant first
+    const size_t size = sizeof(a);
+    const int endian = 0; // native endianness 
+    const size_t nails = 0; // do not skip any bits
+    mpz_import( Pointer(), count, order, size, endian, nails, &a );
+    // We must manually handle the sign
+    if( a < 0 )
+        mpz_neg( Pointer(), Pointer() );
+}
+
+BigInt::BigInt( const char* str, int base, int numBits )
+{
+    DEBUG_ONLY(CSE cse("BigInt::BigInt [char*]"))
+    mpz_init2( Pointer(), numBits );
+    mpz_set_str( Pointer(), str, base );
+}
+
+BigInt::BigInt( const std::string& str, int base, int numBits )
+{
+    DEBUG_ONLY(CSE cse("BigInt::BigInt [string]"))
+    mpz_init2( Pointer(), numBits );
+    mpz_set_str( Pointer(), str.c_str(), base );
+}
+
+// Move constructor
+// ----------------
+BigInt::BigInt( BigInt&& a )
+{
+    DEBUG_ONLY(CSE cse("BigInt::BigInt [move]"))
+    Pointer()->_mp_d = 0;
+    mpz_swap( Pointer(), a.Pointer() );
+}
+
+BigInt::~BigInt()
+{
+    DEBUG_ONLY(CSE cse("BigInt::~BigInt"))
+    if( Pointer()->_mp_d != 0 )
+        mpz_clear( Pointer() );
+}
+
+void BigInt::Zero()
+{
+    DEBUG_ONLY(CSE cse("BigInt::Zero"))
+    mpzInt_->_mp_size = 0;
+}
+
+BigInt& BigInt::operator=( const BigInt& a )
+{
+    DEBUG_ONLY(CSE cse("BigInt::operator= [BigInt]"))
+    mpz_set( Pointer(), a.LockedPointer() );
+    return *this;
+}
+
+BigInt& BigInt::operator=( const unsigned& a )
+{
+    DEBUG_ONLY(CSE cse("BigInt::operator= [unsigned]"))
+    mpz_set_ui( Pointer(), a );
+    return *this;
+}
+
+BigInt& BigInt::operator=( const unsigned long& a )
+{
+    DEBUG_ONLY(CSE cse("BigInt::operator= [unsigned long]"))
+    mpz_set_ui( Pointer(), a );
+    return *this;
+}
+
+BigInt& BigInt::operator=( const unsigned long long& a )
+{
+    DEBUG_ONLY(CSE cse("BigInt::operator= [unsigned long long]"))
+    const size_t count = 1;
+    const int order = 1;  // most-significant first
+    const size_t size = sizeof(a);
+    const int endian = 0; // native endianness 
+    const size_t nails = 0; // do not skip any bits
+    mpz_import( Pointer(), count, order, size, endian, nails, &a );
+    return *this;
+}
+
+BigInt& BigInt::operator=( const int& a )
+{
+    DEBUG_ONLY(CSE cse("BigInt::operator= [int]"))
+    mpz_set_si( Pointer(), a );
+    return *this;
+}
+
+BigInt& BigInt::operator=( const long int& a )
+{
+    DEBUG_ONLY(CSE cse("BigInt::operator= [long int]"))
+    mpz_set_si( Pointer(), a );
+    return *this;
+}
+
+BigInt& BigInt::operator=( const long long int& a )
+{
+    DEBUG_ONLY(CSE cse("BigInt::operator= [long long int]"))
+    const size_t count = 1;
+    const int order = 1;  // most-significant first
+    const size_t size = sizeof(a);
+    const int endian = 0; // native endianness 
+    const size_t nails = 0; // do not skip any bits
+    mpz_import( Pointer(), count, order, size, endian, nails, &a );
+    // We must manually handle the sign
+    if( a < 0 )
+        mpz_neg( Pointer(), Pointer() );
+    return *this;
+}
+
+BigInt& BigInt::operator=( const double& a )
+{
+    DEBUG_ONLY(CSE cse("BigInt::operator= [double]"))
+    mpz_set_d( Pointer(), a );
+    return *this;
+}
+
+BigInt& BigInt::operator=( BigInt&& a )
+{
+    DEBUG_ONLY(CSE cse("BigInt::operator= [move]"))
+    mpz_swap( Pointer(), a.Pointer() );
+    return *this;
+}
+
+BigInt& BigInt::operator+=( const unsigned& a )
+{
+    DEBUG_ONLY(CSE cse("BigInt::operator+= [unsigned]"))
+    mpz_add_ui( Pointer(), Pointer(), a );
+    return *this;
+}
+
+BigInt& BigInt::operator+=( const unsigned long& a )
+{
+    DEBUG_ONLY(CSE cse("BigInt::operator+= [unsigned long]"))
+    mpz_add_ui( Pointer(), Pointer(), a );
+    return *this;
+}
+
+BigInt& BigInt::operator+=( const BigInt& a )
+{
+    DEBUG_ONLY(CSE cse("BigInt::operator+= [BigInt]"))
+    mpz_add( Pointer(), Pointer(), a.LockedPointer() );
+    return *this;
+}
+
+BigInt& BigInt::operator-=( const unsigned& a )
+{
+    DEBUG_ONLY(CSE cse("BigInt::operator-= [unsigned]"))
+    mpz_sub_ui( Pointer(), Pointer(), a );
+    return *this;
+}
+
+BigInt& BigInt::operator-=( const unsigned long& a )
+{
+    DEBUG_ONLY(CSE cse("BigInt::operator-= [unsigned long]"))
+    mpz_sub_ui( Pointer(), Pointer(), a );
+    return *this;
+}
+
+BigInt& BigInt::operator-=( const BigInt& a )
+{
+    DEBUG_ONLY(CSE cse("BigInt::operator-= [BigInt]"))
+    mpz_sub( Pointer(), Pointer(), a.LockedPointer() );
+    return *this;
+}
+
+BigInt& BigInt::operator*=( const int& a )
+{
+    DEBUG_ONLY(CSE cse("BigInt::operator*= [int]"))
+    mpz_mul_si( Pointer(), Pointer(), a );
+    return *this;
+}
+
+BigInt& BigInt::operator*=( const long int& a )
+{
+    DEBUG_ONLY(CSE cse("BigInt::operator*= [long int]"))
+    mpz_mul_si( Pointer(), Pointer(), a );
+    return *this;
+}
+
+BigInt& BigInt::operator*=( const unsigned& a )
+{
+    DEBUG_ONLY(CSE cse("BigInt::operator*= [unsigned]"))
+    mpz_mul_ui( Pointer(), Pointer(), a );
+    return *this;
+}
+
+BigInt& BigInt::operator*=( const unsigned long& a )
+{
+    DEBUG_ONLY(CSE cse("BigInt::operator*= [unsigned long]"))
+    mpz_mul_ui( Pointer(), Pointer(), a );
+    return *this;
+}
+
+BigInt& BigInt::operator*=( const BigInt& a )
+{
+    DEBUG_ONLY(CSE cse("BigInt::operator*= [BigInt]"))
+    mpz_mul( Pointer(), Pointer(), a.LockedPointer() );
+    return *this;
+}
+
+BigInt& BigInt::operator/=( const BigInt& a )
+{
+    DEBUG_ONLY(CSE cse("BigInt::operator/= [BigInt]"))
+    mpz_tdiv_q( Pointer(), Pointer(), a.LockedPointer() );
+    return *this;
+}
+
+BigInt BigInt::operator-() const
+{
+    DEBUG_ONLY(CSE cse("BigInt::operator-"))
+    BigInt alphaNeg(*this);
+    mpz_neg( alphaNeg.Pointer(), alphaNeg.Pointer() );
+    return alphaNeg;
+}
+
+BigInt BigInt::operator+() const
+{
+    DEBUG_ONLY(CSE cse("BigInt::operator+"))
+    BigInt alpha(*this);
+    return alpha;
+}
+
+BigInt& BigInt::operator<<=( const unsigned& a )
+{
+    DEBUG_ONLY(CSE cse("BigInt::operator<<= [unsigned]"))
+    mpz_mul_2exp( Pointer(), Pointer(), a );
+    return *this;
+}
+
+BigInt& BigInt::operator<<=( const unsigned long& a )
+{
+    DEBUG_ONLY(CSE cse("BigInt::operator<<= [unsigned long]"))
+    mpz_mul_2exp( Pointer(), Pointer(), a );
+    return *this;
+}
+
+BigInt& BigInt::operator>>=( const unsigned& a )
+{
+    DEBUG_ONLY(CSE cse("BigInt::operator>>= [unsigned]"))
+    mpz_div_2exp( Pointer(), Pointer(), a );
+    return *this;
+}
+
+BigInt& BigInt::operator>>=( const unsigned long& a )
+{
+    DEBUG_ONLY(CSE cse("BigInt::operator>>= [unsigned long]"))
+    mpz_div_2exp( Pointer(), Pointer(), a );
+    return *this;
+}
+
+BigInt::operator bool() const
+{ return mpz_get_ui(LockedPointer()) != 0; }
+
+BigInt::operator unsigned() const
+{ return unsigned(operator long unsigned()); }
+
+BigInt::operator unsigned long() const
+{ return mpz_get_ui( LockedPointer() ); }
+
+BigInt::operator unsigned long long() const
+{
+    unsigned long long a;
+
+    const size_t neededSize = mpz_sizeinbase(LockedPointer(),2);
+    DEBUG_ONLY(
+      if( neededSize > sizeof(a) )
+          LogicError
+          ("Don't have space for ",neededSize," bits in unsigned long long");
+    )
+
+    const int order = 1;  // most-significant first
+    const size_t size = sizeof(a);
+    const int endian = 0; // native endianness 
+    const size_t nails = 0; // do not skip any bits
+
+    size_t count;
+    mpz_export( &a, &count, order, size, endian, nails, LockedPointer() );
+    return a;
+}
+
+BigInt::operator int() const
+{ return int(operator long int()); }
+
+BigInt::operator long int() const
+{ return mpz_get_si( LockedPointer() ); }
+
+BigInt::operator long long int() const
+{
+    long long int a;
+
+    const size_t neededSize = mpz_sizeinbase(LockedPointer(),2);
+    DEBUG_ONLY(
+      if( neededSize >= sizeof(a) )
+          LogicError
+          ("Don't have space for ",neededSize," bits in long long int");
+    )
+
+    const int order = 1;  // most-significant first
+    const size_t size = sizeof(a);
+    const int endian = 0; // native endianness 
+    const size_t nails = 0; // do not skip any bits
+
+    size_t count;
+    mpz_export( &a, &count, order, size, endian, nails, LockedPointer() );
+    if( *this < 0 )
+        a = -a;
+    return a;
+}
+
+BigInt::operator float() const
+{ return float(operator double()); }
+
+BigInt::operator double() const
+{ return mpz_get_d( LockedPointer() ); }
+
+BigInt::operator long double() const
+{ return (long double)(operator double()); }
+
+#ifdef EL_HAVE_QD
+BigInt::operator DoubleDouble() const
+{
+    DEBUG_ONLY(CSE cse("BigInt::operator DoubleDouble"))
+    // This is not lossless in situations where it could be :-/
+    return DoubleDouble(operator double());
+}
+
+BigInt::operator QuadDouble() const
+{
+    DEBUG_ONLY(CSE cse("BigInt::operator QuadDouble"))
+    // This is not lossless in situations where it could be :-/
+    return QuadDouble(operator double());
+}
+#endif
+
+#ifdef EL_HAVE_QUAD
+BigInt::operator Quad() const
+{
+    DEBUG_ONLY(CSE cse("BigInt::operator Quad"))
+    // This is not lossless in situations where it could be :-/
+    return Quad(operator double());
+}
+#endif
+
+size_t BigInt::ThinSerializedSize() const
+{
+    DEBUG_ONLY(CSE cse("BigInt::ThinSerializedSize"))
+    return sizeof(int) + sizeof(mp_limb_t)*mpzInt_->_mp_size;
+}
+
+size_t BigInt::SerializedSize( int numLimbs ) const
+{
+    DEBUG_ONLY(
+      CSE cse("BigInt::SerializedSize");
+      if( numLimbs < mpzInt_->_mp_size )
+          LogicError
+          ("Upper bound of numLimbs=",numLimbs," < ",mpzInt_->_mp_size);
+    )
+    Output("serialized size: ",sizeof(int)+sizeof(mp_limb_t)*numLimbs);
+    return sizeof(int) + sizeof(mp_limb_t)*numLimbs; 
+}
+
+byte* BigInt::ThinSerialize( byte* buf ) const
+{
+    DEBUG_ONLY(CSE cse("BigInt::ThinSerialize"))
+    // NOTE: We don't have to necessarily serialize the precisions, as
+    //       they are known a priori (as long as the user does not fiddle
+    //       with SetPrecision)
+    std::memcpy( buf, &mpzInt_->_mp_size, sizeof(int) );
+    buf += sizeof(int);
+
+    const int numLimbs = mpzInt_->_mp_size;
+    std::memcpy( buf, mpzInt_->_mp_d, numLimbs*sizeof(mp_limb_t) );
+    buf += sizeof(mp_limb_t);
+
+    return buf;
+}
+
+byte* BigInt::Serialize( byte* buf, int numLimbs ) const
+{
+    DEBUG_ONLY(
+      CSE cse("BigInt::Serialize");
+      if( numLimbs < mpzInt_->_mp_size )
+          LogicError
+          ("Upper bound of numLimbs=",numLimbs," < ",mpzInt_->_mp_size);
+    )
+
+    Output("Serializing with numLimbs=",numLimbs,", GMP_NUMB_BITS=",GMP_NUMB_BITS);
+
+    Output("_mp_size=",mpzInt_->_mp_size,", _mp_alloc=",mpzInt_->_mp_alloc);
+
+    // NOTE: We don't have to necessarily serialize the precisions, as
+    //       they are known a priori (as long as the user does not fiddle
+    //       with SetPrecision)
+    std::memcpy( buf, &mpzInt_->_mp_size, sizeof(int) );
+    buf += sizeof(int);
+
+    const int numUsedLimbs = mpzInt_->_mp_size;
+    std::memcpy( buf, mpzInt_->_mp_d, numUsedLimbs*sizeof(mp_limb_t) );
+    buf += numLimbs*sizeof(mp_limb_t);
+
+    return buf;
+}
+
+const byte* BigInt::ThinDeserialize( const byte* buf )
+{
+    DEBUG_ONLY(CSE cse("BigInt::ThinDeserialize"))
+    int numLimbsDynamic;
+    std::memcpy( &numLimbsDynamic, buf, sizeof(int) );
+    buf += sizeof(int);
+
+    // TODO: Avoid the realloc2 call?
+    const int precDynamic = numLimbsDynamic*GMP_NUMB_BITS;
+    mpz_realloc2( mpzInt_, precDynamic );
+    mpzInt_->_mp_size = numLimbsDynamic;
+    std::memcpy( mpzInt_->_mp_d, buf, numLimbsDynamic*sizeof(mp_limb_t) );
+    buf += numLimbsDynamic*sizeof(mp_limb_t);
+
+    return buf;
+}
+
+const byte* BigInt::Deserialize( const byte* buf, int numLimbs )
+{
+    DEBUG_ONLY(CSE cse("BigInt::Deserialize"))
+    int numLimbsDynamic;
+    std::memcpy( &numLimbsDynamic, buf, sizeof(int) );
+    buf += sizeof(int);
+
+    Output("Deserializing with numLimbs=",numLimbs);
+
+    DEBUG_ONLY(
+      if( numLimbsDynamic > numLimbs )
+          LogicError("numLimbsDynamic=",numLimbsDynamic,", numLimbs=",numLimbs);
+    )
+
+    // TODO: Avoid the realloc2 call?
+    const int prec = numLimbs*GMP_NUMB_BITS;
+    mpz_realloc2( mpzInt_, prec );
+    mpzInt_->_mp_size = numLimbsDynamic;
+    std::memcpy( mpzInt_->_mp_d, buf, numLimbsDynamic*sizeof(mp_limb_t) );
+    buf += numLimbsDynamic*sizeof(mp_limb_t);
+
+    return buf;
+}
+
+byte* BigInt::ThinDeserialize( byte* buf )
+{ return const_cast<byte*>(ThinDeserialize(static_cast<const byte*>(buf))); }
+
+byte* BigInt::Deserialize( byte* buf, int numLimbs )
+{
+    return const_cast<byte*>
+      (Deserialize(static_cast<const byte*>(buf),numLimbs));
+}
+
+BigInt operator+( const BigInt& a, const BigInt& b )
+{ return BigInt(a) += b; }
+
+BigInt operator-( const BigInt& a, const BigInt& b )
+{ return BigInt(a) -= b; }
+
+BigInt operator*( const BigInt& a, const BigInt& b )
+{ return BigInt(a) *= b; }
+
+BigInt operator/( const BigInt& a, const BigInt& b )
+{ return BigInt(a) /= b; }
+
+BigInt operator%( const BigInt& a, const BigInt& b )
+{
+    BigInt c;
+    mpz_mod( c.Pointer(), a.LockedPointer(), b.LockedPointer() );
+    return c;
+}
+
+BigInt operator%( const BigInt& a, const unsigned long& b )
+{
+    BigInt c;
+    mpz_mod_ui( c.Pointer(), a.LockedPointer(), b );
+    return c;
+}
+
+BigInt operator%( const BigInt& a, const unsigned& b )
+{
+    BigInt c;
+    mpz_mod_ui( c.Pointer(), a.LockedPointer(), b );
+    return c;
+}
+
+BigInt operator<<( const BigInt& a, const unsigned& b )
+{ return BigInt(a) <<= b; }
+
+BigInt operator<<( const BigInt& a, const long unsigned& b )
+{ return BigInt(a) <<= b; }
+
+BigInt operator>>( const BigInt& a, const unsigned& b )
+{ return BigInt(a) >>= b; }
+
+BigInt operator>>( const BigInt& a, const long unsigned& b )
+{ return BigInt(a) >>= b; }
+
+bool operator<( const BigInt& a, const BigInt& b )
+{ return mpz_cmp(a.mpzInt_,b.mpzInt_) < 0; }
+
+bool operator<( const BigInt& a, const int& b )
+{ return mpz_cmp_si(a.mpzInt_,b) < 0; }
+
+bool operator<( const BigInt& a, const long int& b )
+{ return mpz_cmp_si(a.mpzInt_,b) < 0; }
+
+bool operator<( const int& a, const BigInt& b )
+{ return mpz_cmp_si(b.mpzInt_,a) > 0; }
+
+bool operator<( const long int& a, const BigInt& b )
+{ return mpz_cmp_si(b.mpzInt_,a) > 0; }
+
+bool operator>( const BigInt& a, const BigInt& b )
+{ return mpz_cmp(a.mpzInt_,b.mpzInt_) > 0; }
+
+bool operator>( const BigInt& a, const int& b )
+{ return mpz_cmp_si(a.mpzInt_,b) > 0; }
+
+bool operator>( const BigInt& a, const long int& b )
+{ return mpz_cmp_si(a.mpzInt_,b) > 0; }
+
+bool operator>( const int& a, const BigInt& b )
+{ return mpz_cmp_si(b.mpzInt_,a) < 0; }
+
+bool operator>( const long int& a, const BigInt& b )
+{ return mpz_cmp_si(b.mpzInt_,a) < 0; }
+
+bool operator<=( const BigInt& a, const BigInt& b )
+{ return mpz_cmp(a.mpzInt_,b.mpzInt_) <= 0; }
+
+bool operator<=( const BigInt& a, const int& b )
+{ return mpz_cmp_si(a.mpzInt_,b) <= 0; }
+
+bool operator<=( const BigInt& a, const long int& b )
+{ return mpz_cmp_si(a.mpzInt_,b) <= 0; }
+
+bool operator<=( const int& a, const BigInt& b )
+{ return mpz_cmp_si(b.mpzInt_,a) >= 0; }
+
+bool operator<=( const long int& a, const BigInt& b )
+{ return mpz_cmp_si(b.mpzInt_,a) >= 0; }
+
+bool operator>=( const BigInt& a, const BigInt& b )
+{ return mpz_cmp(a.mpzInt_,b.mpzInt_) >= 0; }
+
+bool operator>=( const BigInt& a, const int& b )
+{ return mpz_cmp_si(a.mpzInt_,b) >= 0; }
+
+bool operator>=( const BigInt& a, const long int& b )
+{ return mpz_cmp_si(a.mpzInt_,b) >= 0; }
+
+bool operator>=( const int& a, const BigInt& b )
+{ return mpz_cmp_si(b.mpzInt_,a) <= 0; }
+
+bool operator>=( const long int& a, const BigInt& b )
+{ return mpz_cmp_si(b.mpzInt_,a) <= 0; }
+
+bool operator==( const BigInt& a, const BigInt& b )
+{ return mpz_cmp(a.mpzInt_,b.mpzInt_) == 0; }
+
+bool operator==( const BigInt& a, const int& b )
+{ return mpz_cmp_si(a.mpzInt_,b) == 0; }
+
+bool operator==( const BigInt& a, const long int& b )
+{ return mpz_cmp_si(a.mpzInt_,b) == 0; }
+
+bool operator==( const int& a, const BigInt& b )
+{ return mpz_cmp_si(b.mpzInt_,a) == 0; }
+
+bool operator==( const long int& a, const BigInt& b )
+{ return mpz_cmp_si(b.mpzInt_,a) == 0; }
+
+bool operator!=( const BigInt& a, const BigInt& b )
+{ return !(a==b); }
+
+bool operator!=( const BigInt& a, const int& b )
+{ return !(a==b); }
+
+bool operator!=( const BigInt& a, const long int& b )
+{ return !(a==b); }
+
+bool operator!=( const int& a, const BigInt& b )
+{ return !(a==b); }
+
+bool operator!=( const long int& a, const BigInt& b )
+{ return !(a==b); }
+
+std::ostream& operator<<( std::ostream& os, const BigInt& alpha )
+{
+    DEBUG_ONLY(CSE cse("operator<<(std::ostream&,const BigInt&)"))
+    std::ostringstream osFormat;
+    osFormat << "%.";
+    /*
+    if( os.precision() >= 0 )
+        osFormat << os.precision();
+    else
+        osFormat << mpc::BinaryToDecimalPrecision(alpha.Precision())+1;
+    */
+    osFormat << mpc::BinaryToDecimalPrecision(alpha.NumBits())+1;
+    osFormat << "Zd";
+
+    char* rawStr = 0;
+    const int numChar =
+      gmp_asprintf( &rawStr, osFormat.str().c_str(), alpha.LockedPointer() );
+    if( numChar >= 0 )
+    {
+        os << std::string(rawStr);
+        // NOTE: While there is an mpfr_free_str, there is no gmp alternative
+        free( rawStr );
+    }
+    return os;
+}
+
+std::istream& operator>>( std::istream& is, BigInt& alpha )
+{
+    DEBUG_ONLY(CSE cse("operator>>(std::istream&,BigInt&)"))
+    std::string token;
+    is >> token;
+    const int base = 10;
+    mpz_set_str( alpha.Pointer(), token.c_str(), base );
+    return is;
+}
+
+} // namespace El
+
+#endif // ifdef EL_HAVE_MPC

--- a/src/core/imports/mpi.cpp
+++ b/src/core/imports/mpi.cpp
@@ -466,6 +466,30 @@ void PackedTaggedSend( const T* buf, int count, int to, int tag, Comm comm )
     );
 }
 template<>
+void TaggedSend( const BigInt* buf, int count, int to, int tag, Comm comm )
+EL_NO_RELEASE_EXCEPT
+{
+    DEBUG_ONLY(CSE cse("mpi::TaggedSend [BigInt]"))
+    PackedTaggedSend( buf, count, to, tag, comm );
+}
+template<>
+void TaggedSend
+( const ValueInt<BigInt>* buf, int count, int to, int tag, Comm comm )
+EL_NO_RELEASE_EXCEPT
+{
+    DEBUG_ONLY(CSE cse("mpi::TaggedSend [ValueInt<BigInt>]"))
+    PackedTaggedSend( buf, count, to, tag, comm );
+}
+template<>
+void TaggedSend
+( const Entry<BigInt>* buf, int count, int to, int tag, Comm comm )
+EL_NO_RELEASE_EXCEPT
+{
+    DEBUG_ONLY(CSE cse("mpi::TaggedSend [Entry<BigInt>]"))
+    PackedTaggedSend( buf, count, to, tag, comm );
+}
+
+template<>
 void TaggedSend( const BigFloat* buf, int count, int to, int tag, Comm comm )
 EL_NO_RELEASE_EXCEPT
 {
@@ -541,6 +565,33 @@ EL_NO_RELEASE_EXCEPT
     DEBUG_ONLY(CSE cse("mpi::PackedTaggedISend"))
     LogicError
     ("Elemental does not yet support non-blocking BigFloat communication");
+}
+
+template<>
+void TaggedISend
+( const BigInt* buf, int count, int to, int tag, Comm comm, Request& request )
+EL_NO_RELEASE_EXCEPT
+{
+    DEBUG_ONLY(CSE cse("mpi::TaggedISend [BigInt]"))
+    PackedTaggedISend( buf, count, to, tag, comm, request );
+}
+template<>
+void TaggedISend
+( const ValueInt<BigInt>* buf, int count, int to, int tag,
+  Comm comm, Request& request )
+EL_NO_RELEASE_EXCEPT
+{
+    DEBUG_ONLY(CSE cse("mpi::TaggedISend [ValueInt<BigInt>]"))
+    PackedTaggedISend( buf, count, to, tag, comm, request );
+}
+template<>
+void TaggedISend
+( const Entry<BigInt>* buf, int count, int to, int tag,
+  Comm comm, Request& request )
+EL_NO_RELEASE_EXCEPT
+{
+    DEBUG_ONLY(CSE cse("mpi::TaggedISend [Entry<BigInt>]"))
+    PackedTaggedISend( buf, count, to, tag, comm, request );
 }
 
 template<>
@@ -630,6 +681,33 @@ EL_NO_RELEASE_EXCEPT
 
 template<>
 void TaggedISSend
+( const BigInt* buf, int count, int to, int tag, Comm comm, Request& request )
+EL_NO_RELEASE_EXCEPT
+{
+    DEBUG_ONLY(CSE cse("mpi::ISSend [BigInt]"))
+    PackedTaggedISSend( buf, count, to, tag, comm, request );
+}
+template<>
+void TaggedISSend
+( const ValueInt<BigInt>* buf, int count, int to, int tag,
+  Comm comm, Request& request )
+EL_NO_RELEASE_EXCEPT
+{
+    DEBUG_ONLY(CSE cse("mpi::ISSend [ValueInt<BigInt>]"))
+    PackedTaggedISSend( buf, count, to, tag, comm, request );
+}
+template<>
+void TaggedISSend
+( const Entry<BigInt>* buf, int count, int to, int tag,
+  Comm comm, Request& request )
+EL_NO_RELEASE_EXCEPT
+{
+    DEBUG_ONLY(CSE cse("mpi::ISSend [Entry<BigInt>]"))
+    PackedTaggedISSend( buf, count, to, tag, comm, request );
+}
+
+template<>
+void TaggedISSend
 ( const BigFloat* buf, int count, int to, int tag, Comm comm, Request& request )
 EL_NO_RELEASE_EXCEPT
 {
@@ -711,6 +789,29 @@ void PackedTaggedRecv( T* buf, int count, int from, int tag, Comm comm )
 }
 
 template<>
+void TaggedRecv( BigInt* buf, int count, int from, int tag, Comm comm )
+EL_NO_RELEASE_EXCEPT
+{
+    DEBUG_ONLY(CSE cse("mpi::TaggedRecv [BigInt]"))
+    PackedTaggedRecv( buf, count, from, tag, comm );
+}
+template<>
+void TaggedRecv
+( ValueInt<BigInt>* buf, int count, int from, int tag, Comm comm )
+EL_NO_RELEASE_EXCEPT
+{
+    DEBUG_ONLY(CSE cse("mpi::TaggedRecv [ValueInt<BigInt>]"))
+    PackedTaggedRecv( buf, count, from, tag, comm );
+}
+template<>
+void TaggedRecv( Entry<BigInt>* buf, int count, int from, int tag, Comm comm )
+EL_NO_RELEASE_EXCEPT
+{
+    DEBUG_ONLY(CSE cse("mpi::TaggedRecv [Entry<BigInt>]"))
+    PackedTaggedRecv( buf, count, from, tag, comm );
+}
+
+template<>
 void TaggedRecv( BigFloat* buf, int count, int from, int tag, Comm comm )
 EL_NO_RELEASE_EXCEPT
 {
@@ -784,6 +885,33 @@ EL_NO_RELEASE_EXCEPT
     DEBUG_ONLY(CSE cse("mpi::PackedTaggedIRecv"))
     LogicError
     ("Elemental does not yet support non-blocking BigFloat communication");
+}
+
+template<>
+void TaggedIRecv
+( BigInt* buf, int count, int from, int tag, Comm comm, Request& request )
+EL_NO_RELEASE_EXCEPT
+{
+    DEBUG_ONLY(CSE cse("mpi::TaggedIRecv [BigInt]"))
+    PackedTaggedIRecv( buf, count, from, tag, comm, request );
+}
+template<>
+void TaggedIRecv
+( ValueInt<BigInt>* buf, int count, int from, int tag,
+  Comm comm, Request& request )
+EL_NO_RELEASE_EXCEPT
+{
+    DEBUG_ONLY(CSE cse("mpi::TaggedIRecv [ValueInt<BigInt>]"))
+    PackedTaggedIRecv( buf, count, from, tag, comm, request );
+}
+template<>
+void TaggedIRecv
+( Entry<BigInt>* buf, int count, int from, int tag,
+  Comm comm, Request& request )
+EL_NO_RELEASE_EXCEPT
+{
+    DEBUG_ONLY(CSE cse("mpi::TaggedIRecv [Entry<BigInt>]"))
+    PackedTaggedIRecv( buf, count, from, tag, comm, request );
 }
 
 template<>
@@ -877,6 +1005,31 @@ void PackedTaggedSendRecv
         packedRecv.data(), rc, TypeMap<T>(), from, rtag, 
         comm.comm, &status ) );
     Deserialize( rc, packedRecv, rbuf );
+}
+
+template<>
+void TaggedSendRecv
+( const BigInt* sbuf, int sc, int to,   int stag,
+        BigInt* rbuf, int rc, int from, int rtag, Comm comm )
+{
+    DEBUG_ONLY(CSE cse("mpi::TaggedSendRecv [BigInt]"))
+    PackedTaggedSendRecv( sbuf, sc, to, stag, rbuf, rc, from, rtag, comm );
+}
+template<>
+void TaggedSendRecv
+( const ValueInt<BigInt>* sbuf, int sc, int to,   int stag,
+        ValueInt<BigInt>* rbuf, int rc, int from, int rtag, Comm comm )
+{
+    DEBUG_ONLY(CSE cse("mpi::TaggedSendRecv [ValueInt<BigInt>]"))
+    PackedTaggedSendRecv( sbuf, sc, to, stag, rbuf, rc, from, rtag, comm );
+}
+template<>
+void TaggedSendRecv
+( const Entry<BigInt>* sbuf, int sc, int to,   int stag,
+        Entry<BigInt>* rbuf, int rc, int from, int rtag, Comm comm )
+{
+    DEBUG_ONLY(CSE cse("mpi::TaggedSendRecv [Entry<BigInt>]"))
+    PackedTaggedSendRecv( sbuf, sc, to, stag, rbuf, rc, from, rtag, comm );
 }
 
 template<>
@@ -980,6 +1133,33 @@ EL_NO_RELEASE_EXCEPT
 
 template<>
 void TaggedSendRecv
+( BigInt* buf, int count, int to, int stag, int from, int rtag, Comm comm )
+EL_NO_RELEASE_EXCEPT
+{
+    DEBUG_ONLY(CSE cse("mpi::TaggedSendRecv [BigInt]"))
+    PackedTaggedSendRecv( buf, count, to, stag, from, rtag, comm );
+}
+template<>
+void TaggedSendRecv
+( ValueInt<BigInt>* buf, int count, int to, int stag, int from, int rtag,
+  Comm comm )
+EL_NO_RELEASE_EXCEPT
+{
+    DEBUG_ONLY(CSE cse("mpi::TaggedSendRecv [ValueInt<BigInt>]"))
+    PackedTaggedSendRecv( buf, count, to, stag, from, rtag, comm );
+}
+template<>
+void TaggedSendRecv
+( Entry<BigInt>* buf, int count, int to, int stag, int from, int rtag,
+  Comm comm )
+EL_NO_RELEASE_EXCEPT
+{
+    DEBUG_ONLY(CSE cse("mpi::TaggedSendRecv [Entry<BigInt>]"))
+    PackedTaggedSendRecv( buf, count, to, stag, from, rtag, comm );
+}
+
+template<>
+void TaggedSendRecv
 ( BigFloat* buf, int count, int to, int stag, int from, int rtag, Comm comm )
 EL_NO_RELEASE_EXCEPT
 {
@@ -1058,6 +1238,28 @@ EL_NO_RELEASE_EXCEPT
 }
 
 template<>
+void Broadcast( BigInt* buf, int count, int root, Comm comm )
+EL_NO_RELEASE_EXCEPT
+{
+    DEBUG_ONLY(CSE cse("mpi::Broadcast [BigInt]"))
+    PackedBroadcast( buf, count, root, comm );
+}
+template<>
+void Broadcast( ValueInt<BigInt>* buf, int count, int root, Comm comm )
+EL_NO_RELEASE_EXCEPT
+{
+    DEBUG_ONLY(CSE cse("mpi::Broadcast [ValueInt<BigInt>]"))
+    PackedBroadcast( buf, count, root, comm );
+}
+template<>
+void Broadcast( Entry<BigInt>* buf, int count, int root, Comm comm )
+EL_NO_RELEASE_EXCEPT
+{
+    DEBUG_ONLY(CSE cse("mpi::Broadcast [Entry<BigInt>]"))
+    PackedBroadcast( buf, count, root, comm );
+}
+
+template<>
 void Broadcast( BigFloat* buf, int count, int root, Comm comm )
 EL_NO_RELEASE_EXCEPT
 {
@@ -1117,6 +1319,28 @@ void PackedIBroadcast
     DEBUG_ONLY(CSE cse("mpi::PackedIBroadcast"))
     LogicError
     ("Elemental does not yet support non-blocking BigFloat communication");
+}
+
+template<>
+void IBroadcast
+( BigInt* buf, int count, int root, Comm comm, Request& request )
+{
+    DEBUG_ONLY(CSE cse("mpi::IBroadcast [BigInt]"))
+    PackedIBroadcast( buf, count, root, comm, request );
+}
+template<>
+void IBroadcast
+( ValueInt<BigInt>* buf, int count, int root, Comm comm, Request& request )
+{
+    DEBUG_ONLY(CSE cse("mpi::IBroadcast [ValueInt<BigInt>]"))
+    PackedIBroadcast( buf, count, root, comm, request );
+}
+template<>
+void IBroadcast
+( Entry<BigInt>* buf, int count, int root, Comm comm, Request& request )
+{
+    DEBUG_ONLY(CSE cse("mpi::IBroadcast [Entry<BigInt>]"))
+    PackedIBroadcast( buf, count, root, comm, request );
 }
 
 template<>
@@ -1204,6 +1428,34 @@ EL_NO_RELEASE_EXCEPT
 
 template<>
 void Gather
+( const BigInt* sbuf, int sc,
+        BigInt* rbuf, int rc, int root, Comm comm )
+EL_NO_RELEASE_EXCEPT
+{
+    DEBUG_ONLY(CSE cse("mpi::Gather [BigInt]"))
+    PackedGather( sbuf, sc, rbuf, rc, root, comm );
+}
+template<>
+void Gather
+( const ValueInt<BigInt>* sbuf, int sc,
+        ValueInt<BigInt>* rbuf, int rc, int root, Comm comm )
+EL_NO_RELEASE_EXCEPT
+{
+    DEBUG_ONLY(CSE cse("mpi::Gather [ValueInt<BigInt>]"))
+    PackedGather( sbuf, sc, rbuf, rc, root, comm );
+}
+template<>
+void Gather
+( const Entry<BigInt>* sbuf, int sc,
+        Entry<BigInt>* rbuf, int rc, int root, Comm comm )
+EL_NO_RELEASE_EXCEPT
+{
+    DEBUG_ONLY(CSE cse("mpi::Gather [Entry<BigInt>]"))
+    PackedGather( sbuf, sc, rbuf, rc, root, comm );
+}
+
+template<>
+void Gather
 ( const BigFloat* sbuf, int sc,
         BigFloat* rbuf, int rc, int root, Comm comm )
 EL_NO_RELEASE_EXCEPT
@@ -1276,6 +1528,33 @@ void PackedIGather
     DEBUG_ONLY(CSE cse("mpi::PackedIGather"))
     LogicError
     ("Elemental does not yet support non-blocking BigFloat communication");
+}
+
+template<>
+void IGather
+( const BigInt* sbuf, int sc,
+        BigInt* rbuf, int rc, int root, Comm comm, Request& request )
+{
+    DEBUG_ONLY(CSE cse("mpi::IGather [BigInt]"))
+    PackedIGather( sbuf, sc, rbuf, rc, root, comm, request );
+}
+template<>
+void IGather
+( const ValueInt<BigInt>* sbuf, int sc,
+        ValueInt<BigInt>* rbuf, int rc,
+  int root, Comm comm, Request& request )
+{
+    DEBUG_ONLY(CSE cse("mpi::IGather [ValueInt<BigInt>]"))
+    PackedIGather( sbuf, sc, rbuf, rc, root, comm, request );
+}
+template<>
+void IGather
+( const Entry<BigInt>* sbuf, int sc,
+        Entry<BigInt>* rbuf, int rc,
+  int root, Comm comm, Request& request )
+{
+    DEBUG_ONLY(CSE cse("mpi::IGather [Entry<BigInt>]"))
+    PackedIGather( sbuf, sc, rbuf, rc, root, comm, request );
 }
 
 template<>
@@ -1383,6 +1662,36 @@ EL_NO_RELEASE_EXCEPT
         comm.comm ) );
     if( commRank == root )
         Deserialize( totalRecv, packedRecv, rbuf );
+}
+
+template<>
+void Gather
+( const BigInt* sbuf, int sc,
+        BigInt* rbuf, const int* rcs, const int* rds, int root, Comm comm )
+EL_NO_RELEASE_EXCEPT
+{
+    DEBUG_ONLY(CSE cse("mpi::Gather [BigInt]"))
+    PackedGather( sbuf, sc, rbuf, rcs, rds, root, comm );
+}
+template<>
+void Gather
+( const ValueInt<BigInt>* sbuf, int sc,
+        ValueInt<BigInt>* rbuf, const int* rcs, const int* rds,
+  int root, Comm comm )
+EL_NO_RELEASE_EXCEPT
+{
+    DEBUG_ONLY(CSE cse("mpi::Gather [ValueInt<BigInt>]"))
+    PackedGather( sbuf, sc, rbuf, rcs, rds, root, comm );
+}
+template<>
+void Gather
+( const Entry<BigInt>* sbuf, int sc,
+        Entry<BigInt>* rbuf, const int* rcs, const int* rds,
+  int root, Comm comm )
+EL_NO_RELEASE_EXCEPT
+{
+    DEBUG_ONLY(CSE cse("mpi::Gather [Entry<BigInt>]"))
+    PackedGather( sbuf, sc, rbuf, rcs, rds, root, comm );
 }
 
 template<>
@@ -1498,6 +1807,34 @@ EL_NO_RELEASE_EXCEPT
       ( packedSend.data(), sc, TypeMap<T>(),
         packedRecv.data(), rc, TypeMap<T>(), comm.comm ) );
     Deserialize( totalRecv, packedRecv, rbuf );
+}
+
+template<>
+void AllGather
+( const BigInt* sbuf, int sc,
+        BigInt* rbuf, int rc, Comm comm )
+EL_NO_RELEASE_EXCEPT
+{
+    DEBUG_ONLY(CSE cse("mpi::AllGather [BigInt]"))
+    PackedAllGather( sbuf, sc, rbuf, rc, comm );
+}
+template<>
+void AllGather
+( const ValueInt<BigInt>* sbuf, int sc,
+        ValueInt<BigInt>* rbuf, int rc, Comm comm )
+EL_NO_RELEASE_EXCEPT
+{
+    DEBUG_ONLY(CSE cse("mpi::AllGather [ValueInt<BigInt>]"))
+    PackedAllGather( sbuf, sc, rbuf, rc, comm );
+}
+template<>
+void AllGather
+( const Entry<BigInt>* sbuf, int sc,
+        Entry<BigInt>* rbuf, int rc, Comm comm )
+EL_NO_RELEASE_EXCEPT
+{
+    DEBUG_ONLY(CSE cse("mpi::AllGather [Entry<BigInt>]"))
+    PackedAllGather( sbuf, sc, rbuf, rc, comm );
 }
 
 template<>
@@ -1623,6 +1960,34 @@ EL_NO_RELEASE_EXCEPT
 
 template<>
 void AllGather
+( const BigInt* sbuf, int sc,
+        BigInt* rbuf, const int* rcs, const int* rds, Comm comm )
+EL_NO_RELEASE_EXCEPT
+{
+    DEBUG_ONLY(CSE cse("mpi::Allgather [BigInt]"))
+    PackedAllGather( sbuf, sc, rbuf, rcs, rds, comm );
+}
+template<>
+void AllGather
+( const ValueInt<BigInt>* sbuf, int sc,
+        ValueInt<BigInt>* rbuf, const int* rcs, const int* rds, Comm comm )
+EL_NO_RELEASE_EXCEPT
+{
+    DEBUG_ONLY(CSE cse("mpi::Allgather [ValueInt<BigInt>]"))
+    PackedAllGather( sbuf, sc, rbuf, rcs, rds, comm );
+}
+template<>
+void AllGather
+( const Entry<BigInt>* sbuf, int sc,
+        Entry<BigInt>* rbuf, const int* rcs, const int* rds, Comm comm )
+EL_NO_RELEASE_EXCEPT
+{
+    DEBUG_ONLY(CSE cse("mpi::Allgather [Entry<BigInt>]"))
+    PackedAllGather( sbuf, sc, rbuf, rcs, rds, comm );
+}
+
+template<>
+void AllGather
 ( const BigFloat* sbuf, int sc,
         BigFloat* rbuf, const int* rcs, const int* rds, Comm comm )
 EL_NO_RELEASE_EXCEPT
@@ -1738,6 +2103,34 @@ EL_NO_RELEASE_EXCEPT
 
 template<>
 void Scatter
+( const BigInt* sbuf, int sc,
+        BigInt* rbuf, int rc, int root, Comm comm )
+EL_NO_RELEASE_EXCEPT
+{
+    DEBUG_ONLY(CSE cse("mpi::Scatter [BigInt]"))
+    PackedScatter( sbuf, sc, rbuf, rc, root, comm );
+}
+template<>
+void Scatter
+( const ValueInt<BigInt>* sbuf, int sc,
+        ValueInt<BigInt>* rbuf, int rc, int root, Comm comm )
+EL_NO_RELEASE_EXCEPT
+{
+    DEBUG_ONLY(CSE cse("mpi::Scatter [ValueInt<BigInt>]"))
+    PackedScatter( sbuf, sc, rbuf, rc, root, comm );
+}
+template<>
+void Scatter
+( const Entry<BigInt>* sbuf, int sc,
+        Entry<BigInt>* rbuf, int rc, int root, Comm comm )
+EL_NO_RELEASE_EXCEPT
+{
+    DEBUG_ONLY(CSE cse("mpi::Scatter [Entry<BigInt>]"))
+    PackedScatter( sbuf, sc, rbuf, rc, root, comm );
+}
+
+template<>
+void Scatter
 ( const BigFloat* sbuf, int sc,
         BigFloat* rbuf, int rc, int root, Comm comm )
 EL_NO_RELEASE_EXCEPT
@@ -1830,6 +2223,28 @@ EL_NO_RELEASE_EXCEPT
       ( packedSend.data(), sc, TypeMap<T>(),
         packedRecv.data(), rc, TypeMap<T>(), root, comm.comm ) );
     Deserialize( rc, packedRecv, buf );
+}
+
+template<>
+void Scatter( BigInt* buf, int sc, int rc, int root, Comm comm )
+EL_NO_RELEASE_EXCEPT
+{
+    DEBUG_ONLY(CSE cse("mpi::Scatter [BigInt]"))
+    PackedScatter( buf, sc, rc, root, comm );
+}
+template<>
+void Scatter( ValueInt<BigInt>* buf, int sc, int rc, int root, Comm comm )
+EL_NO_RELEASE_EXCEPT
+{
+    DEBUG_ONLY(CSE cse("mpi::Scatter [ValueInt<BigInt>]"))
+    PackedScatter( buf, sc, rc, root, comm );
+}
+template<>
+void Scatter( Entry<BigInt>* buf, int sc, int rc, int root, Comm comm )
+EL_NO_RELEASE_EXCEPT
+{
+    DEBUG_ONLY(CSE cse("mpi::Scatter [Entry<BigInt>]"))
+    PackedScatter( buf, sc, rc, root, comm );
 }
 
 template<>
@@ -1927,6 +2342,34 @@ EL_NO_RELEASE_EXCEPT
 
 template<>
 void AllToAll
+( const BigInt* sbuf, int sc,
+        BigInt* rbuf, int rc, Comm comm )
+EL_NO_RELEASE_EXCEPT
+{
+    DEBUG_ONLY(CSE cse("mpi::AllToAll [BigInt]"))
+    PackedAllToAll( sbuf, sc, rbuf, rc, comm );
+}
+template<>
+void AllToAll
+( const ValueInt<BigInt>* sbuf, int sc,
+        ValueInt<BigInt>* rbuf, int rc, Comm comm )
+EL_NO_RELEASE_EXCEPT
+{
+    DEBUG_ONLY(CSE cse("mpi::AllToAll [ValueInt<BigInt>]"))
+    PackedAllToAll( sbuf, sc, rbuf, rc, comm );
+}
+template<>
+void AllToAll
+( const Entry<BigInt>* sbuf, int sc,
+        Entry<BigInt>* rbuf, int rc, Comm comm )
+EL_NO_RELEASE_EXCEPT
+{
+    DEBUG_ONLY(CSE cse("mpi::AllToAll [Entry<BigInt>]"))
+    PackedAllToAll( sbuf, sc, rbuf, rc, comm );
+}
+
+template<>
+void AllToAll
 ( const BigFloat* sbuf, int sc,
         BigFloat* rbuf, int rc, Comm comm )
 EL_NO_RELEASE_EXCEPT
@@ -2017,6 +2460,34 @@ EL_NO_RELEASE_EXCEPT
         const_cast<int*>(rcs), const_cast<int*>(rds), TypeMap<T>(),
         comm.comm ) );
     Deserialize( totalRecv, packedRecv, rbuf );
+}
+
+template<>
+void AllToAll
+( const BigInt* sbuf, const int* scs, const int* sds,
+        BigInt* rbuf, const int* rcs, const int* rds, Comm comm )
+EL_NO_RELEASE_EXCEPT
+{
+    DEBUG_ONLY(CSE cse("mpi::AllToAll [BigInt]"))
+    PackedAllToAll( sbuf, scs, sds, rbuf, rcs, rds, comm );
+}
+template<>
+void AllToAll
+( const ValueInt<BigInt>* sbuf, const int* scs, const int* sds,
+        ValueInt<BigInt>* rbuf, const int* rcs, const int* rds, Comm comm )
+EL_NO_RELEASE_EXCEPT
+{
+    DEBUG_ONLY(CSE cse("mpi::AllToAll [ValueInt<BigInt>]"))
+    PackedAllToAll( sbuf, scs, sds, rbuf, rcs, rds, comm );
+}
+template<>
+void AllToAll
+( const Entry<BigInt>* sbuf, const int* scs, const int* sds,
+        Entry<BigInt>* rbuf, const int* rcs, const int* rds, Comm comm )
+EL_NO_RELEASE_EXCEPT
+{
+    DEBUG_ONLY(CSE cse("mpi::AllToAll [Entry<BigInt>]"))
+    PackedAllToAll( sbuf, scs, sds, rbuf, rcs, rds, comm );
 }
 
 template<>
@@ -2164,6 +2635,33 @@ EL_NO_RELEASE_EXCEPT
         opC, root, comm.comm ) );
     if( commRank == root )
         Deserialize( count, packedRecv, rbuf );
+}
+
+template<>
+void Reduce
+( const BigInt* sbuf, BigInt* rbuf, int count, Op op, int root, Comm comm )
+EL_NO_RELEASE_EXCEPT
+{
+    DEBUG_ONLY(CSE cse("mpi::Reduce [BigInt]"))
+    PackedReduce( sbuf, rbuf, count, op, root, comm );
+}
+template<>
+void Reduce
+( const ValueInt<BigInt>* sbuf,
+        ValueInt<BigInt>* rbuf, int count, Op op, int root, Comm comm )
+EL_NO_RELEASE_EXCEPT
+{
+    DEBUG_ONLY(CSE cse("mpi::Reduce [ValueInt<BigInt>]"))
+    PackedReduce( sbuf, rbuf, count, op, root, comm );
+}
+template<>
+void Reduce
+( const Entry<BigInt>* sbuf,
+        Entry<BigInt>* rbuf, int count, Op op, int root, Comm comm )
+EL_NO_RELEASE_EXCEPT
+{
+    DEBUG_ONLY(CSE cse("mpi::Reduce [Entry<BigInt>]"))
+    PackedReduce( sbuf, rbuf, count, op, root, comm );
 }
 
 template<>
@@ -2325,6 +2823,28 @@ EL_NO_RELEASE_EXCEPT
 }
 
 template<>
+void Reduce( BigInt* buf, int count, Op op, int root, Comm comm )
+EL_NO_RELEASE_EXCEPT
+{
+    DEBUG_ONLY(CSE cse("mpi::Reduce [BigInt]"))
+    PackedReduce( buf, count, op, root, comm );
+}
+template<>
+void Reduce( ValueInt<BigInt>* buf, int count, Op op, int root, Comm comm )
+EL_NO_RELEASE_EXCEPT
+{
+    DEBUG_ONLY(CSE cse("mpi::Reduce [ValueInt<BigInt>]"))
+    PackedReduce( buf, count, op, root, comm );
+}
+template<>
+void Reduce( Entry<BigInt>* buf, int count, Op op, int root, Comm comm )
+EL_NO_RELEASE_EXCEPT
+{
+    DEBUG_ONLY(CSE cse("mpi::Reduce [Entry<BigInt>]"))
+    PackedReduce( buf, count, op, root, comm );
+}
+
+template<>
 void Reduce( BigFloat* buf, int count, Op op, int root, Comm comm )
 EL_NO_RELEASE_EXCEPT
 {
@@ -2472,6 +2992,33 @@ EL_NO_RELEASE_EXCEPT
 
 template<>
 void AllReduce
+( const BigInt* sbuf, BigInt* rbuf, int count, Op op, Comm comm )
+EL_NO_RELEASE_EXCEPT
+{
+    DEBUG_ONLY(CSE cse("mpi::AllReduce [BigInt]"))
+    PackedAllReduce( sbuf, rbuf, count, op, comm );
+}
+template<>
+void AllReduce
+( const ValueInt<BigInt>* sbuf,
+        ValueInt<BigInt>* rbuf, int count, Op op, Comm comm )
+EL_NO_RELEASE_EXCEPT
+{
+    DEBUG_ONLY(CSE cse("mpi::AllReduce [ValueInt<BigInt>]"))
+    PackedAllReduce( sbuf, rbuf, count, op, comm );
+}
+template<>
+void AllReduce
+( const Entry<BigInt>* sbuf,
+        Entry<BigInt>* rbuf, int count, Op op, Comm comm )
+EL_NO_RELEASE_EXCEPT
+{
+    DEBUG_ONLY(CSE cse("mpi::AllReduce [Entry<BigInt>]"))
+    PackedAllReduce( sbuf, rbuf, count, op, comm );
+}
+
+template<>
+void AllReduce
 ( const BigFloat* sbuf, BigFloat* rbuf, int count, Op op, Comm comm )
 EL_NO_RELEASE_EXCEPT
 {
@@ -2602,6 +3149,28 @@ EL_NO_RELEASE_EXCEPT
       ( packedSend.data(), packedRecv.data(), count, TypeMap<T>(),
         opC, comm.comm ) );
     Deserialize( count, packedRecv, buf );
+}
+
+template<>
+void AllReduce( BigInt* buf, int count, Op op, Comm comm )
+EL_NO_RELEASE_EXCEPT
+{
+    DEBUG_ONLY(CSE cse("mpi::AllReduce [BigInt]"))
+    PackedAllReduce( buf, count, op, comm );
+}
+template<>
+void AllReduce( ValueInt<BigInt>* buf, int count, Op op, Comm comm )
+EL_NO_RELEASE_EXCEPT
+{
+    DEBUG_ONLY(CSE cse("mpi::AllReduce [ValueInt<BigInt>]"))
+    PackedAllReduce( buf, count, op, comm );
+}
+template<>
+void AllReduce( Entry<BigInt>* buf, int count, Op op, Comm comm )
+EL_NO_RELEASE_EXCEPT
+{
+    DEBUG_ONLY(CSE cse("mpi::AllReduce [Entry<BigInt>]"))
+    PackedAllReduce( buf, count, op, comm );
 }
 
 template<>
@@ -2738,6 +3307,32 @@ EL_NO_RELEASE_EXCEPT
     Reduce( sbuf, totalSend, op, 0, comm );
     Scatter( sbuf, rc, rbuf, rc, 0, comm );
 #endif
+}
+
+template<>
+void ReduceScatter( BigInt* sbuf, BigInt* rbuf, int rc, Op op, Comm comm )
+EL_NO_RELEASE_EXCEPT
+{
+    DEBUG_ONLY(CSE cse("mpi::ReduceScatter [BigInt]"))
+    PackedReduceScatter( sbuf, rbuf, rc, op, comm );
+}
+template<>
+void ReduceScatter
+( ValueInt<BigInt>* sbuf,
+  ValueInt<BigInt>* rbuf, int rc, Op op, Comm comm )
+EL_NO_RELEASE_EXCEPT
+{
+    DEBUG_ONLY(CSE cse("mpi::ReduceScatter [ValueInt<BigInt>]"))
+    PackedReduceScatter( sbuf, rbuf, rc, op, comm );
+}
+template<>
+void ReduceScatter
+( Entry<BigInt>* sbuf,
+  Entry<BigInt>* rbuf, int rc, Op op, Comm comm )
+EL_NO_RELEASE_EXCEPT
+{
+    DEBUG_ONLY(CSE cse("mpi::ReduceScatter [Entry<BigInt>]"))
+    PackedReduceScatter( sbuf, rbuf, rc, op, comm );
 }
 
 template<>
@@ -2893,6 +3488,28 @@ EL_NO_RELEASE_EXCEPT
 }
 
 template<>
+void ReduceScatter( BigInt* buf, int rc, Op op, Comm comm )
+EL_NO_RELEASE_EXCEPT
+{
+    DEBUG_ONLY(CSE cse("mpi::ReduceScatter [BigInt]"))
+    PackedReduceScatter( buf, rc, op, comm );
+}
+template<>
+void ReduceScatter( ValueInt<BigInt>* buf, int rc, Op op, Comm comm )
+EL_NO_RELEASE_EXCEPT
+{
+    DEBUG_ONLY(CSE cse("mpi::ReduceScatter [ValueInt<BigInt>]"))
+    PackedReduceScatter( buf, rc, op, comm );
+}
+template<>
+void ReduceScatter( Entry<BigInt>* buf, int rc, Op op, Comm comm )
+EL_NO_RELEASE_EXCEPT
+{
+    DEBUG_ONLY(CSE cse("mpi::ReduceScatter [Entry<BigInt>]"))
+    PackedReduceScatter( buf, rc, op, comm );
+}
+
+template<>
 void ReduceScatter( BigFloat* buf, int rc, Op op, Comm comm )
 EL_NO_RELEASE_EXCEPT
 {
@@ -3011,6 +3628,33 @@ EL_NO_RELEASE_EXCEPT
       ( packedSend.data(), packedRecv.data(), const_cast<int*>(rcs),
         TypeMap<T>(), opC, comm.comm ) );
     Deserialize( totalRecv, packedRecv, rbuf );
+}
+
+template<>
+void ReduceScatter
+( const BigInt* sbuf, BigInt* rbuf, const int* rcs, Op op, Comm comm )
+EL_NO_RELEASE_EXCEPT
+{
+    DEBUG_ONLY(CSE cse("mpi::ReduceScatter [BigInt]"))
+    PackedReduceScatter( sbuf, rbuf, rcs, op, comm );
+}
+template<>
+void ReduceScatter
+( const ValueInt<BigInt>* sbuf,
+        ValueInt<BigInt>* rbuf, const int* rcs, Op op, Comm comm )
+EL_NO_RELEASE_EXCEPT
+{
+    DEBUG_ONLY(CSE cse("mpi::ReduceScatter [ValueInt<BigInt>]"))
+    PackedReduceScatter( sbuf, rbuf, rcs, op, comm );
+}
+template<>
+void ReduceScatter
+( const Entry<BigInt>* sbuf,
+        Entry<BigInt>* rbuf, const int* rcs, Op op, Comm comm )
+EL_NO_RELEASE_EXCEPT
+{
+    DEBUG_ONLY(CSE cse("mpi::ReduceScatter [Entry<BigInt>]"))
+    PackedReduceScatter( sbuf, rbuf, rcs, op, comm );
 }
 
 template<>
@@ -3161,6 +3805,33 @@ EL_NO_RELEASE_EXCEPT
 
 template<>
 void Scan
+( const BigInt* sbuf, BigInt* rbuf, int count, Op op, Comm comm )
+EL_NO_RELEASE_EXCEPT
+{
+    DEBUG_ONLY(CSE cse("mpi::Scan [BigInt]"))
+    PackedScan( sbuf, rbuf, count, op, comm );
+}
+template<>
+void Scan
+( const ValueInt<BigInt>* sbuf,
+        ValueInt<BigInt>* rbuf, int count, Op op, Comm comm )
+EL_NO_RELEASE_EXCEPT
+{
+    DEBUG_ONLY(CSE cse("mpi::Scan [ValueInt<BigInt>]"))
+    PackedScan( sbuf, rbuf, count, op, comm );
+}
+template<>
+void Scan
+( const Entry<BigInt>* sbuf,
+        Entry<BigInt>* rbuf, int count, Op op, Comm comm )
+EL_NO_RELEASE_EXCEPT
+{
+    DEBUG_ONLY(CSE cse("mpi::Scan [Entry<BigInt>]"))
+    PackedScan( sbuf, rbuf, count, op, comm );
+}
+
+template<>
+void Scan
 ( const BigFloat* sbuf, BigFloat* rbuf, int count, Op op, Comm comm )
 EL_NO_RELEASE_EXCEPT
 {
@@ -3299,6 +3970,28 @@ EL_NO_RELEASE_EXCEPT
       ( packedSend.data(), packedRecv.data(), count, TypeMap<T>(),
         opC, comm.comm ) );
     Deserialize( count, packedRecv, buf );
+}
+
+template<>
+void Scan( BigInt* buf, int count, Op op, Comm comm )
+EL_NO_RELEASE_EXCEPT
+{
+    DEBUG_ONLY(CSE cse("mpi::Scan [BigInt]"))
+    PackedScan( buf, count, op, comm );
+}
+template<>
+void Scan( ValueInt<BigInt>* buf, int count, Op op, Comm comm )
+EL_NO_RELEASE_EXCEPT
+{
+    DEBUG_ONLY(CSE cse("mpi::Scan [ValueInt<BigInt>]"))
+    PackedScan( buf, count, op, comm );
+}
+template<>
+void Scan( Entry<BigInt>* buf, int count, Op op, Comm comm )
+EL_NO_RELEASE_EXCEPT
+{
+    DEBUG_ONLY(CSE cse("mpi::Scan [Entry<BigInt>]"))
+    PackedScan( buf, count, op, comm );
 }
 
 template<>
@@ -3621,10 +4314,13 @@ MPI_PROTO(Entry<Quad>)
 MPI_PROTO(Entry<Complex<Quad>>)
 #endif
 #ifdef EL_HAVE_MPC
+MPI_PROTO(BigInt)
 MPI_PROTO(BigFloat)
 // TODO: MPI_PROTO(Complex<BigFloat>)
+MPI_PROTO(ValueInt<BigInt>)
 MPI_PROTO(ValueInt<BigFloat>)
 // TODO: MPI_PROTO(ValueInt<Complex<BigFloat>>)
+MPI_PROTO(Entry<BigInt>)
 MPI_PROTO(Entry<BigFloat>)
 // TODO: MPI_PROTO(Entry<Complex<BigFloat>>)
 #endif
@@ -3642,6 +4338,7 @@ MPI_PROTO(Entry<BigFloat>)
 #define EL_ENABLE_DOUBLEDOUBLE
 #define EL_ENABLE_QUADDOUBLE
 #define EL_ENABLE_QUAD
+#define EL_ENABLE_BIGINT
 #define EL_ENABLE_BIGFLOAT
 #include "El/macros/Instantiate.h"
 

--- a/src/core/imports/mpi.cpp
+++ b/src/core/imports/mpi.cpp
@@ -1123,6 +1123,7 @@ EL_NO_RELEASE_EXCEPT
     DEBUG_ONLY(CSE cse("mpi::PackedTaggedSendRecv"))
     std::vector<byte> packedBuf;
     ReserveSerialized( count, buf, packedBuf );
+    Serialize( count, buf, packedBuf );
     Status status;
     SafeMpi
     ( MPI_Sendrecv_replace

--- a/src/core/imports/openblas.cpp
+++ b/src/core/imports/openblas.cpp
@@ -159,6 +159,10 @@ template void omatcopy
 #ifdef EL_HAVE_MPC
 template void omatcopy
 ( Orientation orientation, BlasInt m, BlasInt n,
+  BigInt alpha, const BigInt* A, BlasInt lda,
+                      BigInt* B, BlasInt ldb );
+template void omatcopy
+( Orientation orientation, BlasInt m, BlasInt n,
   BigFloat alpha, const BigFloat* A, BlasInt lda,
                         BigFloat* B, BlasInt ldb );
 #endif
@@ -235,6 +239,9 @@ template void imatcopy
   Complex<Quad> alpha, Complex<Quad>* A, BlasInt lda, BlasInt ldb );
 #endif
 #ifdef EL_HAVE_MPC
+template void imatcopy
+( Orientation orientation, BlasInt m, BlasInt n,
+  BigInt alpha, BigInt* A, BlasInt lda, BlasInt ldb );
 template void imatcopy
 ( Orientation orientation, BlasInt m, BlasInt n,
   BigFloat alpha, BigFloat* A, BlasInt lda, BlasInt ldb );

--- a/src/core/mpi_register.cpp
+++ b/src/core/mpi_register.cpp
@@ -190,7 +190,7 @@ void CreateBigIntType()
 {
     BigInt alpha;
     const auto packedSize = alpha.SerializedSize();
-    const auto numLimbs = alpha.NumLimbs();
+    const int numLimbs = mpc::NumIntLimbs();
 
     mpi::Datatype typeList[3];
     typeList[0] = mpi::TypeMap<int>();

--- a/src/core/mpi_register.cpp
+++ b/src/core/mpi_register.cpp
@@ -20,6 +20,7 @@ using El::Quad;
 #endif
 using El::Complex;
 #ifdef EL_HAVE_MPC
+using El::BigInt;
 using El::BigFloat;
 #endif
 using std::function;
@@ -36,7 +37,7 @@ El::mpi::Datatype DoubleDoubleType, QuadDoubleType;
 El::mpi::Datatype QuadType, QuadComplexType;
 #endif
 #ifdef EL_HAVE_MPC
-El::mpi::Datatype BigFloatType;
+El::mpi::Datatype BigIntType, BigFloatType;
 #endif
 
 // (Int,Scalar) datatypes
@@ -50,7 +51,7 @@ El::mpi::Datatype DoubleDoubleIntType, QuadDoubleIntType;
 El::mpi::Datatype QuadIntType, QuadComplexIntType;
 #endif
 #ifdef EL_HAVE_MPC
-El::mpi::Datatype BigFloatIntType;
+El::mpi::Datatype BigIntIntType, BigFloatIntType;
 #endif
 
 // (Int,Int,Scalar) datatypes
@@ -64,7 +65,7 @@ El::mpi::Datatype DoubleDoubleEntryType, QuadDoubleEntryType;
 El::mpi::Datatype QuadEntryType, QuadComplexEntryType;
 #endif
 #ifdef EL_HAVE_MPC
-El::mpi::Datatype BigFloatEntryType;
+El::mpi::Datatype BigIntEntryType, BigFloatEntryType;
 #endif
 
 // Operations
@@ -81,8 +82,11 @@ El::mpi::Op minQuadOp, maxQuadOp;
 El::mpi::Op sumQuadOp, sumQuadComplexOp;
 #endif
 #ifdef EL_HAVE_MPC
+El::mpi::Op minBigIntOp, maxBigIntOp;
+El::mpi::Op sumBigIntOp;
+
 El::mpi::Op minBigFloatOp, maxBigFloatOp;
-El::mpi::Op sumBigFloatOp, sumMPComplexOp;
+El::mpi::Op sumBigFloatOp;
 #endif
 
 // (Int,Scalar) datatype operations
@@ -98,6 +102,7 @@ El::mpi::Op minLocQuadDoubleOp, maxLocQuadDoubleOp;
 El::mpi::Op minLocQuadOp, maxLocQuadOp;
 #endif
 #ifdef EL_HAVE_MPC
+El::mpi::Op minLocBigIntOp, maxLocBigIntOp;
 El::mpi::Op minLocBigFloatOp, maxLocBigFloatOp;
 #endif
 
@@ -114,6 +119,7 @@ El::mpi::Op minLocPairQuadDoubleOp, maxLocPairQuadDoubleOp;
 El::mpi::Op minLocPairQuadOp, maxLocPairQuadOp;
 #endif
 #ifdef EL_HAVE_MPC
+El::mpi::Op minLocPairBigIntOp, maxLocPairBigIntOp;
 El::mpi::Op minLocPairBigFloatOp, maxLocPairBigFloatOp;
 #endif
 
@@ -158,6 +164,10 @@ El::mpi::Op userComplexQuadOp, userComplexQuadCommOp;
 #endif
 
 #ifdef EL_HAVE_MPC
+function<BigInt(const BigInt&,const BigInt&)>
+  userBigIntFunc, userBigIntCommFunc;
+El::mpi::Op userBigIntOp, userBigIntCommOp;
+
 function<BigFloat(const BigFloat&,const BigFloat&)>
   userBigFloatFunc, userBigFloatCommFunc;
 El::mpi::Op userBigFloatOp, userBigFloatCommOp;
@@ -175,6 +185,38 @@ namespace El {
 namespace mpi {
 
 #ifdef EL_HAVE_MPC
+
+void CreateBigIntType()
+{
+    BigInt alpha;
+    const auto packedSize = alpha.SerializedSize();
+    const auto numLimbs = alpha.NumLimbs();
+
+    mpi::Datatype typeList[3];
+    typeList[0] = mpi::TypeMap<int>();
+    typeList[1] = mpi::TypeMap<mp_limb_t>();
+    typeList[2] = MPI_UB;
+    
+    int blockLengths[3];
+    blockLengths[0] = 1;
+    blockLengths[1] = numLimbs;
+    blockLengths[2] = 1;
+
+    MPI_Aint displs[3];
+    displs[0] = 0;
+    displs[1] = sizeof(int);
+    displs[2] = packedSize;
+
+    int err;
+    err =
+      MPI_Type_create_struct
+      ( 3, blockLengths, displs, typeList, &::BigIntType );
+    if( err != MPI_SUCCESS )
+        RuntimeError("MPI_Type_create_struct returned with err=",err);
+    err = MPI_Type_commit( &::BigIntType );
+    if( err != MPI_SUCCESS )
+        RuntimeError("MPI_Type_commit returned with err=",err);
+}
 
 void CreateBigFloatType()
 {
@@ -655,6 +697,111 @@ EL_NO_EXCEPT
 #endif // ifdef EL_HAVE_QUAD
 
 #ifdef EL_HAVE_MPC
+
+template<>
+void SetUserReduceFunc
+( function<BigInt(const BigInt&,const BigInt&)> func, bool commutative )
+{
+    if( commutative )
+        ::userBigIntCommFunc = func;
+    else
+        ::userBigIntFunc = func;
+}
+
+static void
+UserBigIntReduce
+( void* inVoid, void* outVoid, int* lengthPtr, Datatype* datatype )
+EL_NO_EXCEPT
+{
+    BigInt a, b;
+    auto inData  = static_cast<const byte*>(inVoid);
+    auto outData = static_cast<      byte*>(outVoid);
+    const int length = *lengthPtr;
+    for( int j=0; j<length; ++j )
+    {
+        inData = a.Deserialize(inData);
+        b.Deserialize(outData);
+
+        b = ::userBigIntFunc(a,b);
+        outData = b.Serialize(outData); 
+    }
+}
+
+static void
+UserBigIntReduceComm
+( void* inVoid, void* outVoid, int* lengthPtr, Datatype* datatype )
+EL_NO_EXCEPT
+{
+    BigInt a, b;
+    auto inData  = static_cast<const byte*>(inVoid);
+    auto outData = static_cast<      byte*>(outVoid);
+    const int length = *lengthPtr;
+    for( int j=0; j<length; ++j )
+    {
+        inData = a.Deserialize(inData);
+        b.Deserialize(outData);
+
+        b = ::userBigIntCommFunc(a,b);
+        outData = b.Serialize(outData); 
+    }
+}
+
+static void
+MaxBigInt( void* inVoid, void* outVoid, int* lengthPtr, Datatype* datatype )
+EL_NO_EXCEPT
+{
+    BigInt a, b;
+    auto inData  = static_cast<const byte*>(inVoid);
+    auto outData = static_cast<      byte*>(outVoid);
+    const int length = *lengthPtr;
+    for( int j=0; j<length; ++j )
+    {
+        inData = a.Deserialize(inData);
+        auto bAfter = b.Deserialize(outData);
+
+        if( a > b )
+            a.Serialize(outData);
+        outData = bAfter;
+    }
+}
+
+static void
+MinBigInt( void* inVoid, void* outVoid, int* lengthPtr, Datatype* datatype )
+EL_NO_EXCEPT
+{
+    BigInt a, b;
+    auto inData  = static_cast<const byte*>(inVoid);
+    auto outData = static_cast<      byte*>(outVoid);
+    const int length = *lengthPtr;
+    for( int j=0; j<length; ++j )
+    {
+        inData = a.Deserialize(inData);
+        auto bAfter = b.Deserialize(outData);
+
+        if( a < b )
+            a.Serialize(outData);
+        outData = bAfter;
+    }
+}
+
+static void
+SumBigInt( void* inVoid, void* outVoid, int* lengthPtr, Datatype* datatype )
+EL_NO_EXCEPT
+{
+    BigInt a, b;
+    auto inData  = static_cast<const byte*>(inVoid);
+    auto outData = static_cast<      byte*>(outVoid);
+    const int length = *lengthPtr;
+    for( int j=0; j<length; ++j )
+    {
+        inData = a.Deserialize(inData);
+        b.Deserialize(outData);
+
+        b += a;
+        outData = b.Serialize(outData); 
+    }
+}
+
 template<>
 void SetUserReduceFunc
 ( function<BigFloat(const BigFloat&,const BigFloat&)> func, bool commutative )
@@ -781,6 +928,27 @@ EL_NO_EXCEPT
 
 #ifdef EL_HAVE_MPC
 template<>
+void MaxLocFunc<BigInt>
+( void* inVoid, void* outVoid, int* lengthPtr, Datatype* datatype )
+EL_NO_EXCEPT
+{
+    ValueInt<BigInt> a, b;
+    auto inData  = static_cast<const byte*>(inVoid);
+    auto outData = static_cast<      byte*>(outVoid);
+    const int length = *lengthPtr;
+    for( int j=0; j<length; ++j )
+    {
+        inData = Deserialize( 1, inData,  &a );
+                 Deserialize( 1, outData, &b );
+
+        if( a.value > b.value || (a.value == b.value && a.index < b.index) )
+            outData = Serialize( 1, &a, outData );
+        else
+            outData += a.value.SerializedSize();
+    }
+}
+
+template<>
 void MaxLocFunc<BigFloat>
 ( void* inVoid, void* outVoid, int* lengthPtr, Datatype* datatype )
 EL_NO_EXCEPT
@@ -845,6 +1013,28 @@ EL_NO_EXCEPT
 }
 
 #ifdef EL_HAVE_MPC
+template<>
+void MaxLocPairFunc<BigInt>
+( void* inVoid, void* outVoid, int* lengthPtr, Datatype* datatype )
+EL_NO_EXCEPT
+{
+    Entry<BigInt> a, b;
+    auto inData  = static_cast<const byte*>(inVoid);
+    auto outData = static_cast<      byte*>(outVoid);
+    const int length = *lengthPtr;
+    for( int j=0; j<length; ++j )
+    {
+        inData = Deserialize( 1, inData,  &a );
+                 Deserialize( 1, outData, &b );
+
+        bool inIndLess = ( a.i < b.i || (a.i == b.i && a.j < b.j) );
+        if( a.value > b.value || (a.value == b.value && inIndLess) )
+            outData = Serialize( 1, &a, outData );
+        else
+            outData += a.value.SerializedSize();
+    }
+}
+
 template<>
 void MaxLocPairFunc<BigFloat>
 ( void* inVoid, void* outVoid, int* lengthPtr, Datatype* datatype )
@@ -914,6 +1104,27 @@ EL_NO_EXCEPT
 
 #ifdef EL_HAVE_MPC
 template<>
+void MinLocFunc<BigInt>
+( void* inVoid, void* outVoid, int* lengthPtr, Datatype* datatype )
+EL_NO_EXCEPT
+{
+    ValueInt<BigInt> a, b;
+    auto inData  = static_cast<const byte*>(inVoid);
+    auto outData = static_cast<      byte*>(outVoid);
+    const int length = *lengthPtr;
+    for( int j=0; j<length; ++j )
+    {
+        inData = Deserialize( 1, inData,  &a );
+                 Deserialize( 1, outData, &b );
+
+        if( a.value < b.value || (a.value == b.value && a.index < b.index) )
+            outData = Serialize( 1, &a, outData );
+        else
+            outData += a.value.SerializedSize();
+    }
+}
+
+template<>
 void MinLocFunc<BigFloat>
 ( void* inVoid, void* outVoid, int* lengthPtr, Datatype* datatype )
 EL_NO_EXCEPT
@@ -978,6 +1189,28 @@ EL_NO_EXCEPT
 }
 
 #ifdef EL_HAVE_MPC
+template<>
+void MinLocPairFunc<BigInt>
+( void* inVoid, void* outVoid, int* lengthPtr, Datatype* datatype )
+EL_NO_EXCEPT
+{
+    Entry<BigInt> a, b;
+    auto inData  = static_cast<const byte*>(inVoid);
+    auto outData = static_cast<      byte*>(outVoid);
+    const int length = *lengthPtr;
+    for( int j=0; j<length; ++j )
+    {
+        inData = Deserialize( 1, inData,  &a );
+                 Deserialize( 1, outData, &b );
+
+        bool inIndLess = ( a.i < b.i || (a.i == b.i && a.j < b.j) );
+        if( a.value < b.value || (a.value == b.value && inIndLess) )
+            outData = Serialize( 1, &a, outData );
+        else
+            outData += a.value.SerializedSize();
+    }
+}
+
 template<>
 void MinLocPairFunc<BigFloat>
 ( void* inVoid, void* outVoid, int* lengthPtr, Datatype* datatype )
@@ -1056,6 +1289,8 @@ Datatype& ValueIntType<Complex<Quad>>() EL_NO_EXCEPT
 #endif
 #ifdef EL_HAVE_MPC
 template<>
+Datatype& ValueIntType<BigInt>() EL_NO_EXCEPT { return ::BigIntIntType; }
+template<>
 Datatype& ValueIntType<BigFloat>() EL_NO_EXCEPT { return ::BigFloatIntType; }
 #endif
 
@@ -1088,6 +1323,8 @@ Datatype& EntryType<Complex<Quad>>() EL_NO_EXCEPT
 { return ::QuadComplexEntryType; }
 #endif
 #ifdef EL_HAVE_MPC
+template<>
+Datatype& EntryType<BigInt>() EL_NO_EXCEPT { return ::BigIntEntryType; }
 template<>
 Datatype& EntryType<BigFloat>() EL_NO_EXCEPT { return ::BigFloatEntryType; }
 #endif
@@ -1126,6 +1363,7 @@ template<> Datatype TypeMap<Complex<Quad>>() EL_NO_EXCEPT
 { return ::QuadComplexType; }
 #endif
 #ifdef EL_HAVE_MPC
+template<> Datatype TypeMap<BigInt>() EL_NO_EXCEPT { return ::BigIntType; }
 template<> Datatype TypeMap<BigFloat>() EL_NO_EXCEPT { return ::BigFloatType; }
 // TODO: Complex<BigFloat>?
 #endif
@@ -1179,6 +1417,8 @@ template<> Datatype TypeMap<ValueInt<Complex<Quad>>>() EL_NO_EXCEPT
 { return ValueIntType<Complex<Quad>>(); }
 #endif
 #ifdef EL_HAVE_MPC
+template<> Datatype TypeMap<ValueInt<BigInt>>() EL_NO_EXCEPT
+{ return ValueIntType<BigInt>(); }
 template<> Datatype TypeMap<ValueInt<BigFloat>>() EL_NO_EXCEPT
 { return ValueIntType<BigFloat>(); }
 #endif
@@ -1206,6 +1446,8 @@ template<> Datatype TypeMap<Entry<Complex<Quad>>>() EL_NO_EXCEPT
 { return EntryType<Complex<Quad>>(); }
 #endif
 #ifdef EL_HAVE_MPC
+template<> Datatype TypeMap<Entry<BigInt>>() EL_NO_EXCEPT
+{ return EntryType<BigInt>(); }
 template<> Datatype TypeMap<Entry<BigFloat>>() EL_NO_EXCEPT
 { return EntryType<BigFloat>(); }
 #endif
@@ -1246,6 +1488,38 @@ static void CreateValueIntType() EL_NO_EXCEPT
 }
 
 #ifdef EL_HAVE_MPC
+template<>
+void CreateValueIntType<BigInt>() EL_NO_EXCEPT
+{
+    DEBUG_ONLY(CSE cse("CreateValueIntType [BigInt]"))
+    Datatype typeList[3];
+    typeList[0] = TypeMap<BigInt>();
+    typeList[1] = TypeMap<Int>();
+    typeList[2] = MPI_UB;
+    
+    int blockLengths[3];
+    blockLengths[0] = 1;
+    blockLengths[1] = 1; 
+    blockLengths[2] = 1;
+
+    BigInt alpha;
+    const size_t packedSize = alpha.SerializedSize();
+
+    MPI_Aint displs[3];
+    displs[0] = 0;
+    displs[1] = packedSize;
+    displs[2] = packedSize + sizeof(Int);
+
+    Datatype& type = ValueIntType<BigInt>();
+    int err;
+    err = MPI_Type_create_struct( 3, blockLengths, displs, typeList, &type );
+    if( err != MPI_SUCCESS )
+        RuntimeError("MPI_Type_create_struct returned with err=",err);
+    err = MPI_Type_commit( &type );
+    if( err != MPI_SUCCESS )
+        RuntimeError("MPI_Type_commit returned with err=",err);
+}
+
 template<>
 void CreateValueIntType<BigFloat>() EL_NO_EXCEPT
 {
@@ -1334,6 +1608,41 @@ static void CreateEntryType() EL_NO_EXCEPT
 
 #ifdef EL_HAVE_MPC
 template<>
+void CreateEntryType<BigInt>() EL_NO_EXCEPT
+{
+    DEBUG_ONLY(CSE cse("CreateEntryType [BigInt]"))
+    Datatype typeList[4];
+    typeList[0] = TypeMap<Int>();
+    typeList[1] = TypeMap<Int>();
+    typeList[2] = TypeMap<BigInt>();
+    typeList[3] = MPI_UB;
+    
+    int blockLengths[4];
+    blockLengths[0] = 1;
+    blockLengths[1] = 1; 
+    blockLengths[2] = 1; 
+    blockLengths[3] = 1;
+
+    BigInt alpha;
+    const auto packedSize = alpha.SerializedSize();
+
+    MPI_Aint displs[4];
+    displs[0] = 0;
+    displs[1] = sizeof(Int);
+    displs[2] = 2*sizeof(Int);
+    displs[3] = 2*sizeof(Int) + packedSize;
+
+    Datatype& type = EntryType<BigInt>();
+    int err;
+    err = MPI_Type_create_struct( 4, blockLengths, displs, typeList, &type );
+    if( err != MPI_SUCCESS )
+        RuntimeError("MPI_Type_create_struct returned with err=",err);
+    err = MPI_Type_commit( &type );
+    if( err != MPI_SUCCESS )
+        RuntimeError("MPI_Type_commit returned with err=",err);
+}
+
+template<>
 void CreateEntryType<BigFloat>() EL_NO_EXCEPT
 {
     DEBUG_ONLY(CSE cse("CreateEntryType [BigFloat]"))
@@ -1384,6 +1693,13 @@ template void CreateEntryType<Complex<Quad>>() EL_NO_EXCEPT;
 #endif
 
 #ifdef EL_HAVE_MPC
+void CreateBigIntFamily()
+{
+    CreateBigIntType();
+    CreateValueIntType<BigInt>();
+    CreateEntryType<BigInt>();
+}
+
 void CreateBigFloatFamily()
 {
     CreateBigFloatType();
@@ -1391,11 +1707,18 @@ void CreateBigFloatFamily()
     CreateEntryType<BigFloat>();
 }
 
+void DestroyBigIntFamily()
+{
+    Free( EntryType<BigInt>() );
+    Free( ValueIntType<BigInt>() );
+    Free( ::BigIntType );
+}
+
 void DestroyBigFloatFamily()
 {
-    Free( ::BigFloatType );
-    Free( ValueIntType<BigFloat>() );
     Free( EntryType<BigFloat>() );
+    Free( ValueIntType<BigFloat>() );
+    Free( ::BigFloatType );
 }
 #endif
 
@@ -1548,6 +1871,11 @@ void CreateCustom() EL_NO_RELEASE_EXCEPT
 #endif
 #ifdef EL_HAVE_MPC
     Create
+    ( (UserFunction*)UserBigIntReduce, false, ::userBigIntOp );
+    Create
+    ( (UserFunction*)UserBigIntReduceComm, true, ::userBigIntCommOp );
+
+    Create
     ( (UserFunction*)UserBigFloatReduce, false, ::userBigFloatOp );
     Create
     ( (UserFunction*)UserBigFloatReduceComm, true, ::userBigFloatCommOp );
@@ -1572,6 +1900,10 @@ void CreateCustom() EL_NO_RELEASE_EXCEPT
     Create( (UserFunction*)SumQuadComplex, true, ::sumQuadComplexOp );
 #endif
 #ifdef EL_HAVE_MPC
+    Create( (UserFunction*)MaxBigInt, true, ::maxBigIntOp );
+    Create( (UserFunction*)MinBigInt, true, ::minBigIntOp );
+    Create( (UserFunction*)SumBigInt, true, ::sumBigIntOp );
+
     Create( (UserFunction*)MaxBigFloat, true, ::maxBigFloatOp );
     Create( (UserFunction*)MinBigFloat, true, ::minBigFloatOp );
     Create( (UserFunction*)SumBigFloat, true, ::sumBigFloatOp );
@@ -1607,6 +1939,9 @@ void CreateCustom() EL_NO_RELEASE_EXCEPT
     Create( (UserFunction*)MinLocFunc<Quad>, true, ::minLocQuadOp );
 #endif
 #ifdef EL_HAVE_MPC
+    Create( (UserFunction*)MaxLocFunc<BigInt>, true, ::maxLocBigIntOp );
+    Create( (UserFunction*)MinLocFunc<BigInt>, true, ::minLocBigIntOp );
+
     Create( (UserFunction*)MaxLocFunc<BigFloat>, true, ::maxLocBigFloatOp );
     Create( (UserFunction*)MinLocFunc<BigFloat>, true, ::minLocBigFloatOp );
 #endif
@@ -1638,6 +1973,11 @@ void CreateCustom() EL_NO_RELEASE_EXCEPT
     Create( (UserFunction*)MinLocPairFunc<Quad>,   true, ::minLocPairQuadOp );
 #endif
 #ifdef EL_HAVE_MPC
+    Create
+    ( (UserFunction*)MaxLocPairFunc<BigInt>, true, ::maxLocPairBigIntOp );
+    Create
+    ( (UserFunction*)MinLocPairFunc<BigInt>, true, ::minLocPairBigIntOp );
+
     Create
     ( (UserFunction*)MaxLocPairFunc<BigFloat>, true, ::maxLocPairBigFloatOp );
     Create
@@ -1688,6 +2028,7 @@ void DestroyCustom() EL_NO_RELEASE_EXCEPT
     Free( ::QuadComplexType );
 #endif
 #ifdef EL_HAVE_MPC
+    mpi::DestroyBigIntFamily();
     mpi::DestroyBigFloatFamily();
 #endif
 
@@ -1719,6 +2060,8 @@ void DestroyCustom() EL_NO_RELEASE_EXCEPT
     Free( ::userComplexQuadCommOp );
 #endif
 #ifdef EL_HAVE_MPC
+    Free( ::userBigIntOp );
+    Free( ::userBigIntCommOp );
     Free( ::userBigFloatOp );
     Free( ::userBigFloatCommOp );
 #endif
@@ -1738,6 +2081,9 @@ void DestroyCustom() EL_NO_RELEASE_EXCEPT
     Free( ::sumQuadComplexOp );
 #endif
 #ifdef EL_HAVE_MPC
+    Free( ::maxBigIntOp );
+    Free( ::minBigIntOp );
+    Free( ::sumBigIntOp );
     Free( ::maxBigFloatOp );
     Free( ::minBigFloatOp );
     Free( ::sumBigFloatOp );
@@ -1762,6 +2108,8 @@ void DestroyCustom() EL_NO_RELEASE_EXCEPT
     Free( ::minLocQuadOp );
 #endif
 #ifdef EL_HAVE_MPC
+    Free( ::maxLocBigIntOp );
+    Free( ::minLocBigIntOp );
     Free( ::maxLocBigFloatOp );
     Free( ::minLocBigFloatOp );
 #endif
@@ -1783,6 +2131,8 @@ void DestroyCustom() EL_NO_RELEASE_EXCEPT
     Free( ::minLocPairQuadOp );
 #endif
 #ifdef EL_HAVE_MPC
+    Free( ::maxLocPairBigIntOp );
+    Free( ::minLocPairBigIntOp );
     Free( ::maxLocPairBigFloatOp );
     Free( ::minLocPairBigFloatOp );
 #endif
@@ -1823,6 +2173,11 @@ template<> Op UserCommOp<Complex<Quad>>() EL_NO_EXCEPT
 { return ::userComplexQuadCommOp; }
 #endif
 #ifdef EL_HAVE_MPC
+template<> Op UserOp<BigInt>() EL_NO_EXCEPT
+{ return ::userBigIntOp; }
+template<> Op UserCommOp<BigInt>() EL_NO_EXCEPT
+{ return ::userBigIntCommOp; }
+
 template<> Op UserOp<BigFloat>() EL_NO_EXCEPT
 { return ::userBigFloatOp; }
 template<> Op UserCommOp<BigFloat>() EL_NO_EXCEPT
@@ -1846,9 +2201,12 @@ template<> Op SumOp<Quad>() EL_NO_EXCEPT { return ::sumQuadOp; }
 template<> Op SumOp<Complex<Quad>>() EL_NO_EXCEPT { return ::sumQuadComplexOp; }
 #endif
 #ifdef EL_HAVE_MPC
+template<> Op MaxOp<BigInt>() EL_NO_EXCEPT { return ::maxBigIntOp; }
+template<> Op MinOp<BigInt>() EL_NO_EXCEPT { return ::minBigIntOp; }
+template<> Op SumOp<BigInt>() EL_NO_EXCEPT { return ::sumBigIntOp; }
+
 template<> Op MaxOp<BigFloat>() EL_NO_EXCEPT { return ::maxBigFloatOp; }
 template<> Op MinOp<BigFloat>() EL_NO_EXCEPT { return ::minBigFloatOp; }
-
 template<> Op SumOp<BigFloat>() EL_NO_EXCEPT { return ::sumBigFloatOp; }
 #endif
 
@@ -1874,6 +2232,9 @@ template<> Op MaxLocOp<Quad>() EL_NO_EXCEPT { return ::maxLocQuadOp; }
 template<> Op MinLocOp<Quad>() EL_NO_EXCEPT { return ::minLocQuadOp; }
 #endif
 #ifdef EL_HAVE_MPC
+template<> Op MaxLocOp<BigInt>() EL_NO_EXCEPT { return ::maxLocBigIntOp; }
+template<> Op MinLocOp<BigInt>() EL_NO_EXCEPT { return ::minLocBigIntOp; }
+
 template<> Op MaxLocOp<BigFloat>() EL_NO_EXCEPT { return ::maxLocBigFloatOp; }
 template<> Op MinLocOp<BigFloat>() EL_NO_EXCEPT { return ::minLocBigFloatOp; }
 #endif
@@ -1908,6 +2269,11 @@ template<> Op MinLocPairOp<Quad>() EL_NO_EXCEPT
 { return ::minLocPairQuadOp; }
 #endif
 #ifdef EL_HAVE_MPC
+template<> Op MaxLocPairOp<BigInt>() EL_NO_EXCEPT
+{ return ::maxLocPairBigIntOp; }
+template<> Op MinLocPairOp<BigInt>() EL_NO_EXCEPT
+{ return ::minLocPairBigIntOp; }
+
 template<> Op MaxLocPairOp<BigFloat>() EL_NO_EXCEPT
 { return ::maxLocPairBigFloatOp; }
 template<> Op MinLocPairOp<BigFloat>() EL_NO_EXCEPT

--- a/src/core/random.cpp
+++ b/src/core/random.cpp
@@ -17,7 +17,7 @@ Int CoinFlip() { return ( BooleanCoinFlip() ? 1 : -1 ); }
 
 #ifdef EL_HAVE_QD
 template<>
-DoubleDouble SampleUniform( DoubleDouble a, DoubleDouble b )
+DoubleDouble SampleUniform( const DoubleDouble& a, const DoubleDouble& b )
 {
     DoubleDouble sample;
     // TODO: Use a better random number generator
@@ -32,7 +32,7 @@ DoubleDouble SampleUniform( DoubleDouble a, DoubleDouble b )
 }
 
 template<>
-QuadDouble SampleUniform( QuadDouble a, QuadDouble b )
+QuadDouble SampleUniform( const QuadDouble& a, const QuadDouble& b )
 {
     QuadDouble sample;
     // TODO: Use a better random number generator
@@ -50,7 +50,7 @@ QuadDouble SampleUniform( QuadDouble a, QuadDouble b )
 
 #ifdef EL_HAVE_QUAD
 template<>
-Quad SampleUniform( Quad a, Quad b )
+Quad SampleUniform( const Quad& a, const Quad& b )
 {
     Quad sample;
 #ifdef EL_HAVE_CXX11RANDOM
@@ -65,7 +65,7 @@ Quad SampleUniform( Quad a, Quad b )
 }
 
 template<>
-Complex<Quad> SampleUniform( Complex<Quad> a, Complex<Quad> b )
+Complex<Quad> SampleUniform( const Complex<Quad>& a, const Complex<Quad>& b )
 {
     Complex<Quad> sample;
 
@@ -96,7 +96,19 @@ Complex<Quad> SampleUniform( Complex<Quad> a, Complex<Quad> b )
 
 #ifdef EL_HAVE_MPC
 template<>
-BigFloat SampleUniform( BigFloat a, BigFloat b )
+BigInt SampleUniform( const BigInt& a, const BigInt& b )
+{
+    BigInt sample; 
+    gmp_randstate_t randState;
+    mpc::RandomState( randState );
+
+    mpz_urandomb( sample.Pointer(), randState, sample.NumBits() );
+
+    return a + sample*(b-a);
+}
+
+template<>
+BigFloat SampleUniform( const BigFloat& a, const BigFloat& b )
 {
     BigFloat sample; 
     gmp_randstate_t randState;
@@ -113,7 +125,7 @@ BigFloat SampleUniform( BigFloat a, BigFloat b )
 #endif // ifdef EL_HAVE_MPC
 
 template<>
-Int SampleUniform<Int>( Int a, Int b )
+Int SampleUniform<Int>( const Int& a, const Int& b )
 {
 #ifdef EL_HAVE_CXX11RANDOM
     std::mt19937& gen = Generator();
@@ -123,10 +135,12 @@ Int SampleUniform<Int>( Int a, Int b )
     return a + (rand() % (b-a));
 #endif
 }
+// TODO: BigInt version?
 
 #ifdef EL_HAVE_QD
 template<>
-DoubleDouble SampleNormal( DoubleDouble mean, DoubleDouble stddev )
+DoubleDouble
+SampleNormal( const DoubleDouble& mean, const DoubleDouble& stddev )
 {
     DoubleDouble sample;
 
@@ -158,7 +172,7 @@ DoubleDouble SampleNormal( DoubleDouble mean, DoubleDouble stddev )
 }
 
 template<>
-QuadDouble SampleNormal( QuadDouble mean, QuadDouble stddev )
+QuadDouble SampleNormal( const QuadDouble& mean, const QuadDouble& stddev )
 {
     QuadDouble sample;
 
@@ -192,7 +206,7 @@ QuadDouble SampleNormal( QuadDouble mean, QuadDouble stddev )
 
 #ifdef EL_HAVE_QUAD
 template<>
-Quad SampleNormal( Quad mean, Quad stddev )
+Quad SampleNormal( const Quad& mean, const Quad& stddev )
 {
     Quad sample;
 
@@ -224,7 +238,7 @@ Quad SampleNormal( Quad mean, Quad stddev )
 }
 
 template<>
-Complex<Quad> SampleNormal( Complex<Quad> mean, Quad stddev )
+Complex<Quad> SampleNormal( const Complex<Quad>& mean, const Quad& stddev )
 {
     Complex<Quad> sample;
     stddev = stddev / Sqrt(Quad(2));
@@ -265,7 +279,7 @@ Complex<Quad> SampleNormal( Complex<Quad> mean, Quad stddev )
 
 #ifdef EL_HAVE_MPC
 template<>
-BigFloat SampleNormal( BigFloat mean, BigFloat stddev )
+BigFloat SampleNormal( const BigFloat& mean, const BigFloat& stddev )
 {
     BigFloat sample;
 
@@ -289,14 +303,5 @@ BigFloat SampleNormal( BigFloat mean, BigFloat stddev )
     return sample;
 }
 #endif // ifdef EL_HAVE_MPC
-
-// There is likely to be a significantly better way to define this;
-// the current implementation is simply a placeholder
-template<>
-Int SampleBall<Int>( Int center, Int radius )
-{
-    const double u = SampleBall<double>( center, radius );
-    return std::lround(u);
-}
 
 } // namespace El

--- a/src/core/random.cpp
+++ b/src/core/random.cpp
@@ -101,10 +101,9 @@ BigInt SampleUniform( const BigInt& a, const BigInt& b )
     BigInt sample; 
     gmp_randstate_t randState;
     mpc::RandomState( randState );
-
-    mpz_urandomb( sample.Pointer(), randState, sample.NumBits() );
-
-    return a + sample*(b-a);
+    
+    mpz_urandomb( sample.Pointer(), randState, b.NumBits() );
+    return a+Mod(sample,b-a);
 }
 
 template<>
@@ -241,17 +240,18 @@ template<>
 Complex<Quad> SampleNormal( const Complex<Quad>& mean, const Quad& stddev )
 {
     Complex<Quad> sample;
-    stddev = stddev / Sqrt(Quad(2));
+    Quad stddevAdj = stddev;
+    stddevAdj /= Sqrt(Quad(2));
 
 #ifdef EL_HAVE_CXX11RANDOM
     std::mt19937& gen = Generator();
 
     std::normal_distribution<long double> 
-      realNormal( (long double)RealPart(mean), (long double)stddev );
+      realNormal( (long double)RealPart(mean), (long double)stddevAdj );
     SetRealPart( sample, Quad(realNormal(gen)) );
 
     std::normal_distribution<long double>
-      imagNormal( (long double)ImagPart(mean), (long double)stddev );
+      imagNormal( (long double)ImagPart(mean), (long double)stddevAdj );
     SetImagPart( sample, Quad(imagNormal(gen)) );
 #else
     // Run Marsiglia's polar method
@@ -266,8 +266,8 @@ Complex<Quad> SampleNormal( const Complex<Quad>& mean, const Quad& stddev )
         if( S > Quad(0) && S < Quad(1) )
         {
             const Quad W = Sqrt(-2*Log(S)/S);
-            SetRealPart( sample, RealPart(mean) + stddev*U*W );
-            SetImagPart( sample, ImagPart(mean) + stddev*V*W );
+            SetRealPart( sample, RealPart(mean) + stddevAdj*U*W );
+            SetImagPart( sample, ImagPart(mean) + stddevAdj*V*W );
             break;
         }
     }

--- a/src/io/Display.cpp
+++ b/src/io/Display.cpp
@@ -334,6 +334,7 @@ void DisplayLocal
 #define EL_ENABLE_DOUBLEDOUBLE
 #define EL_ENABLE_QUADDOUBLE
 #define EL_ENABLE_QUAD
+#define EL_ENABLE_BIGINT
 #define EL_ENABLE_BIGFLOAT
 #include "El/macros/Instantiate.h"
 

--- a/src/io/Print.cpp
+++ b/src/io/Print.cpp
@@ -177,6 +177,7 @@ void Print( const vector<T>& x, string title, ostream& os )
 #define EL_ENABLE_DOUBLEDOUBLE
 #define EL_ENABLE_QUADDOUBLE
 #define EL_ENABLE_QUAD
+#define EL_ENABLE_BIGINT
 #define EL_ENABLE_BIGFLOAT
 #include "El/macros/Instantiate.h"
 

--- a/src/io/README.md
+++ b/src/io/README.md
@@ -1,9 +1,0 @@
-### `src/io/`
-
-This folder contains the source-level implementations of Elemental's 
-input/output functionality. Please see `include/El/io` for the 
-header-level implementations. In addition to this file, this folder contains:
-
--  `ComplexDisplayWindow.cpp`: a Qt5-based graphical display of a complex matrix
--  `DisplayWindow.cpp`: a Qt5-based graphical display of a real matrix
--  `SpyWindow.cpp`: a Qt5-based graphical display of the nonzeros of a matrix

--- a/src/io/Read.cpp
+++ b/src/io/Read.cpp
@@ -112,6 +112,7 @@ void Read
 #define EL_ENABLE_DOUBLEDOUBLE
 #define EL_ENABLE_QUADDOUBLE
 #define EL_ENABLE_QUAD
+#define EL_ENABLE_BIGINT
 #define EL_ENABLE_BIGFLOAT
 #include "El/macros/Instantiate.h"
 

--- a/src/io/Spy.cpp
+++ b/src/io/Spy.cpp
@@ -73,6 +73,7 @@ void Spy( const AbstractDistMatrix<T>& A, string title, Base<T> tol )
 #define EL_ENABLE_DOUBLEDOUBLE
 #define EL_ENABLE_QUADDOUBLE
 #define EL_ENABLE_QUAD
+#define EL_ENABLE_BIGINT
 #define EL_ENABLE_BIGFLOAT
 #include "El/macros/Instantiate.h"
 

--- a/src/io/Write.cpp
+++ b/src/io/Write.cpp
@@ -73,6 +73,7 @@ void Write
 #define EL_ENABLE_DOUBLEDOUBLE
 #define EL_ENABLE_QUADDOUBLE
 #define EL_ENABLE_QUAD
+#define EL_ENABLE_BIGINT
 #define EL_ENABLE_BIGFLOAT
 #include "El/macros/Instantiate.h"
 

--- a/src/lapack_like/perm/DistPermutation.cpp
+++ b/src/lapack_like/perm/DistPermutation.cpp
@@ -1187,6 +1187,7 @@ void DistPermutation::ExplicitMatrix( AbstractDistMatrix<Int>& P ) const
 #define EL_ENABLE_DOUBLEDOUBLE
 #define EL_ENABLE_QUADDOUBLE
 #define EL_ENABLE_QUAD
+#define EL_ENABLE_BIGINT
 #define EL_ENABLE_BIGFLOAT
 #include "El/macros/Instantiate.h"
 

--- a/src/lapack_like/perm/Permutation.cpp
+++ b/src/lapack_like/perm/Permutation.cpp
@@ -784,6 +784,7 @@ void Permutation::ExplicitMatrix( Matrix<Int>& P ) const
 #define EL_ENABLE_DOUBLEDOUBLE
 #define EL_ENABLE_QUADDOUBLE
 #define EL_ENABLE_QUAD
+#define EL_ENABLE_BIGINT
 #define EL_ENABLE_BIGFLOAT
 #include "El/macros/Instantiate.h"
 

--- a/src/lapack_like/props/Norm/Max.cpp
+++ b/src/lapack_like/props/Norm/Max.cpp
@@ -252,6 +252,7 @@ Base<T> SymmetricMaxNorm( UpperOrLower uplo, const DistSparseMatrix<T>& A )
 #define EL_ENABLE_DOUBLEDOUBLE
 #define EL_ENABLE_QUADDOUBLE
 #define EL_ENABLE_QUAD
+#define EL_ENABLE_BIGINT
 #define EL_ENABLE_BIGFLOAT
 #include "El/macros/Instantiate.h"
 

--- a/src/lapack_like/props/Norm/Zero.cpp
+++ b/src/lapack_like/props/Norm/Zero.cpp
@@ -74,6 +74,7 @@ Int ZeroNorm( const DistSparseMatrix<T>& A, Base<T> tol )
 #define EL_ENABLE_DOUBLEDOUBLE
 #define EL_ENABLE_QUADDOUBLE
 #define EL_ENABLE_QUAD
+#define EL_ENABLE_BIGINT
 #define EL_ENABLE_BIGFLOAT
 #include "El/macros/Instantiate.h"
 

--- a/src/lapack_like/util/Median.cpp
+++ b/src/lapack_like/util/Median.cpp
@@ -57,6 +57,7 @@ ValueInt<Real> Median( const ElementalMatrix<Real>& x )
 #define EL_ENABLE_DOUBLEDOUBLE
 #define EL_ENABLE_QUADDOUBLE
 #define EL_ENABLE_QUAD
+#define EL_ENABLE_BIGINT
 #define EL_ENABLE_BIGFLOAT
 #include "El/macros/Instantiate.h"
 

--- a/src/lapack_like/util/Sort.cpp
+++ b/src/lapack_like/util/Sort.cpp
@@ -115,6 +115,7 @@ TaggedSort( const ElementalMatrix<Real>& x, SortType sort )
 #define EL_ENABLE_DOUBLEDOUBLE
 #define EL_ENABLE_QUADDOUBLE
 #define EL_ENABLE_QUAD
+#define EL_ENABLE_BIGINT
 #define EL_ENABLE_BIGFLOAT
 #include "El/macros/Instantiate.h"
 

--- a/src/matrices/Bernoulli.cpp
+++ b/src/matrices/Bernoulli.cpp
@@ -53,6 +53,7 @@ void Bernoulli( AbstractDistMatrix<T>& A, Int m, Int n, double p )
 #define EL_ENABLE_DOUBLEDOUBLE
 #define EL_ENABLE_QUADDOUBLE
 #define EL_ENABLE_QUAD
+#define EL_ENABLE_BIGINT
 #define EL_ENABLE_BIGFLOAT
 #include "El/macros/Instantiate.h"
 

--- a/src/matrices/Circulant.cpp
+++ b/src/matrices/Circulant.cpp
@@ -39,6 +39,7 @@ void Circulant( AbstractDistMatrix<T>& A, const vector<T>& a )
 #define EL_ENABLE_DOUBLEDOUBLE
 #define EL_ENABLE_QUADDOUBLE
 #define EL_ENABLE_QUAD
+#define EL_ENABLE_BIGINT
 #define EL_ENABLE_BIGFLOAT
 #include "El/macros/Instantiate.h"
 

--- a/src/matrices/Diagonal.cpp
+++ b/src/matrices/Diagonal.cpp
@@ -144,6 +144,7 @@ void Diagonal( DistSparseMatrix<S>& D, const DistMultiVec<T>& d )
 #define EL_ENABLE_DOUBLEDOUBLE
 #define EL_ENABLE_QUADDOUBLE
 #define EL_ENABLE_QUAD
+#define EL_ENABLE_BIGINT
 #define EL_ENABLE_BIGFLOAT
 #include "El/macros/Instantiate.h"
 

--- a/src/matrices/DynamicRegCounter.cpp
+++ b/src/matrices/DynamicRegCounter.cpp
@@ -123,6 +123,7 @@ void DynamicRegCounter( DistSparseMatrix<T>& A, Int n )
 #define EL_ENABLE_DOUBLEDOUBLE
 #define EL_ENABLE_QUADDOUBLE
 #define EL_ENABLE_QUAD
+#define EL_ENABLE_BIGINT
 #define EL_ENABLE_BIGFLOAT
 #include "El/macros/Instantiate.h"
 

--- a/src/matrices/Forsythe.cpp
+++ b/src/matrices/Forsythe.cpp
@@ -36,6 +36,7 @@ void Forsythe( AbstractDistMatrix<T>& J, Int n, T alpha, T lambda )
 #define EL_ENABLE_DOUBLEDOUBLE
 #define EL_ENABLE_QUADDOUBLE
 #define EL_ENABLE_QUAD
+#define EL_ENABLE_BIGINT
 #define EL_ENABLE_BIGFLOAT
 #include "El/macros/Instantiate.h"
 

--- a/src/matrices/GCDMatrix.cpp
+++ b/src/matrices/GCDMatrix.cpp
@@ -35,6 +35,7 @@ void GCDMatrix( AbstractDistMatrix<T>& G, Int m, Int n )
 #define EL_ENABLE_DOUBLEDOUBLE
 #define EL_ENABLE_QUADDOUBLE
 #define EL_ENABLE_QUAD
+#define EL_ENABLE_BIGINT
 #define EL_ENABLE_BIGFLOAT
 #include "El/macros/Instantiate.h"
 

--- a/src/matrices/GEPPGrowth.cpp
+++ b/src/matrices/GEPPGrowth.cpp
@@ -52,6 +52,7 @@ void GEPPGrowth( ElementalMatrix<T>& A, Int n )
 #define EL_ENABLE_DOUBLEDOUBLE
 #define EL_ENABLE_QUADDOUBLE
 #define EL_ENABLE_QUAD
+#define EL_ENABLE_BIGINT
 #define EL_ENABLE_BIGFLOAT
 #include "El/macros/Instantiate.h"
 

--- a/src/matrices/Gear.cpp
+++ b/src/matrices/Gear.cpp
@@ -47,6 +47,7 @@ void Gear( AbstractDistMatrix<T>& G, Int n, Int s, Int t )
 #define EL_ENABLE_DOUBLEDOUBLE
 #define EL_ENABLE_QUADDOUBLE
 #define EL_ENABLE_QUAD
+#define EL_ENABLE_BIGINT
 #define EL_ENABLE_BIGFLOAT
 #include "El/macros/Instantiate.h"
 

--- a/src/matrices/Grcar.cpp
+++ b/src/matrices/Grcar.cpp
@@ -43,6 +43,7 @@ void Grcar( AbstractDistMatrix<T>& A, Int n, Int k )
 #define EL_ENABLE_DOUBLEDOUBLE
 #define EL_ENABLE_QUADDOUBLE
 #define EL_ENABLE_QUAD
+#define EL_ENABLE_BIGINT
 #define EL_ENABLE_BIGFLOAT
 #include "El/macros/Instantiate.h"
 

--- a/src/matrices/Hankel.cpp
+++ b/src/matrices/Hankel.cpp
@@ -45,6 +45,7 @@ void Hankel( AbstractDistMatrix<T>& A, Int m, Int n, const vector<T>& a )
 #define EL_ENABLE_DOUBLEDOUBLE
 #define EL_ENABLE_QUADDOUBLE
 #define EL_ENABLE_QUAD
+#define EL_ENABLE_BIGINT
 #define EL_ENABLE_BIGFLOAT
 #include "El/macros/Instantiate.h"
 

--- a/src/matrices/Hanowa.cpp
+++ b/src/matrices/Hanowa.cpp
@@ -74,6 +74,7 @@ void Hanowa( ElementalMatrix<T>& A, Int n, T mu )
 #define EL_ENABLE_DOUBLEDOUBLE
 #define EL_ENABLE_QUADDOUBLE
 #define EL_ENABLE_QUAD
+#define EL_ENABLE_BIGINT
 #define EL_ENABLE_BIGFLOAT
 #include "El/macros/Instantiate.h"
 

--- a/src/matrices/Identity.cpp
+++ b/src/matrices/Identity.cpp
@@ -83,6 +83,7 @@ void Identity( DistSparseMatrix<T>& I, Int m, Int n )
 #define EL_ENABLE_DOUBLEDOUBLE
 #define EL_ENABLE_QUADDOUBLE
 #define EL_ENABLE_QUAD
+#define EL_ENABLE_BIGINT
 #define EL_ENABLE_BIGFLOAT
 #include "El/macros/Instantiate.h"
 

--- a/src/matrices/Jordan.cpp
+++ b/src/matrices/Jordan.cpp
@@ -35,6 +35,7 @@ void Jordan( AbstractDistMatrix<T>& J, Int n, T lambda )
 #define EL_ENABLE_DOUBLEDOUBLE
 #define EL_ENABLE_QUADDOUBLE
 #define EL_ENABLE_QUAD
+#define EL_ENABLE_BIGINT
 #define EL_ENABLE_BIGFLOAT
 #include "El/macros/Instantiate.h"
 

--- a/src/matrices/JordanCholesky.cpp
+++ b/src/matrices/JordanCholesky.cpp
@@ -97,6 +97,7 @@ void JordanCholesky( DistSparseMatrix<T>& A, Int n )
 #define EL_ENABLE_DOUBLEDOUBLE
 #define EL_ENABLE_QUADDOUBLE
 #define EL_ENABLE_QUAD
+#define EL_ENABLE_BIGINT
 #define EL_ENABLE_BIGFLOAT
 #include "El/macros/Instantiate.h"
 

--- a/src/matrices/KMS.cpp
+++ b/src/matrices/KMS.cpp
@@ -41,6 +41,7 @@ void KMS( AbstractDistMatrix<T>& K, Int n, T rho )
 #define EL_ENABLE_DOUBLEDOUBLE
 #define EL_ENABLE_QUADDOUBLE
 #define EL_ENABLE_QUAD
+#define EL_ENABLE_BIGINT
 #define EL_ENABLE_BIGFLOAT
 #include "El/macros/Instantiate.h"
 

--- a/src/matrices/Lauchli.cpp
+++ b/src/matrices/Lauchli.cpp
@@ -46,6 +46,7 @@ void Lauchli( ElementalMatrix<T>& A, Int n, T mu )
 #define EL_ENABLE_DOUBLEDOUBLE
 #define EL_ENABLE_QUADDOUBLE
 #define EL_ENABLE_QUAD
+#define EL_ENABLE_BIGINT
 #define EL_ENABLE_BIGFLOAT
 #include "El/macros/Instantiate.h"
 

--- a/src/matrices/MinIJ.cpp
+++ b/src/matrices/MinIJ.cpp
@@ -35,6 +35,7 @@ void MinIJ( AbstractDistMatrix<T>& M, Int n )
 #define EL_ENABLE_DOUBLEDOUBLE
 #define EL_ENABLE_QUADDOUBLE
 #define EL_ENABLE_QUAD
+#define EL_ENABLE_BIGINT
 #define EL_ENABLE_BIGFLOAT
 #include "El/macros/Instantiate.h"
 

--- a/src/matrices/OneTwoOne.cpp
+++ b/src/matrices/OneTwoOne.cpp
@@ -37,6 +37,7 @@ void OneTwoOne( AbstractDistMatrix<T>& A, Int n )
 #define EL_ENABLE_DOUBLEDOUBLE
 #define EL_ENABLE_QUADDOUBLE
 #define EL_ENABLE_QUAD
+#define EL_ENABLE_BIGINT
 #define EL_ENABLE_BIGFLOAT
 #include "El/macros/Instantiate.h"
 

--- a/src/matrices/Ones.cpp
+++ b/src/matrices/Ones.cpp
@@ -60,6 +60,7 @@ void Ones( DistSparseMatrix<T>& A, Int m, Int n )
 #define EL_ENABLE_DOUBLEDOUBLE
 #define EL_ENABLE_QUADDOUBLE
 #define EL_ENABLE_QUAD
+#define EL_ENABLE_BIGINT
 #define EL_ENABLE_BIGFLOAT
 #include "El/macros/Instantiate.h"
 

--- a/src/matrices/Pei.cpp
+++ b/src/matrices/Pei.cpp
@@ -33,6 +33,7 @@ void Pei( AbstractDistMatrix<T>& P, Int n, T alpha )
 #define EL_ENABLE_DOUBLEDOUBLE
 #define EL_ENABLE_QUADDOUBLE
 #define EL_ENABLE_QUAD
+#define EL_ENABLE_BIGINT
 #define EL_ENABLE_BIGFLOAT
 #include "El/macros/Instantiate.h"
 

--- a/src/matrices/Rademacher.cpp
+++ b/src/matrices/Rademacher.cpp
@@ -31,6 +31,7 @@ void Rademacher( AbstractDistMatrix<T>& A, Int m, Int n )
 #define EL_ENABLE_DOUBLEDOUBLE
 #define EL_ENABLE_QUADDOUBLE
 #define EL_ENABLE_QUAD
+#define EL_ENABLE_BIGINT
 #define EL_ENABLE_BIGFLOAT
 #include "El/macros/Instantiate.h"
 

--- a/src/matrices/Redheffer.cpp
+++ b/src/matrices/Redheffer.cpp
@@ -41,6 +41,7 @@ void Redheffer( AbstractDistMatrix<T>& R, Int n )
 #define EL_ENABLE_DOUBLEDOUBLE
 #define EL_ENABLE_QUADDOUBLE
 #define EL_ENABLE_QUAD
+#define EL_ENABLE_BIGINT
 #define EL_ENABLE_BIGFLOAT
 #include "El/macros/Instantiate.h"
 

--- a/src/matrices/ThreeValued.cpp
+++ b/src/matrices/ThreeValued.cpp
@@ -44,6 +44,7 @@ void ThreeValued( AbstractDistMatrix<T>& A, Int m, Int n, double p )
 #define EL_ENABLE_DOUBLEDOUBLE
 #define EL_ENABLE_QUADDOUBLE
 #define EL_ENABLE_QUAD
+#define EL_ENABLE_BIGINT
 #define EL_ENABLE_BIGFLOAT
 #include "El/macros/Instantiate.h"
 

--- a/src/matrices/Toeplitz.cpp
+++ b/src/matrices/Toeplitz.cpp
@@ -56,6 +56,7 @@ void Toeplitz( AbstractDistMatrix<S>& A, Int m, Int n, const vector<T>& a )
 #define EL_ENABLE_DOUBLEDOUBLE
 #define EL_ENABLE_QUADDOUBLE
 #define EL_ENABLE_QUAD
+#define EL_ENABLE_BIGINT
 #define EL_ENABLE_BIGFLOAT
 #include "El/macros/Instantiate.h"
 

--- a/src/matrices/TriW.cpp
+++ b/src/matrices/TriW.cpp
@@ -41,6 +41,7 @@ void TriW( AbstractDistMatrix<T>& A, Int n, T alpha, Int k )
 #define EL_ENABLE_DOUBLEDOUBLE
 #define EL_ENABLE_QUADDOUBLE
 #define EL_ENABLE_QUAD
+#define EL_ENABLE_BIGINT
 #define EL_ENABLE_BIGFLOAT
 #include "El/macros/Instantiate.h"
 

--- a/src/matrices/Uniform.cpp
+++ b/src/matrices/Uniform.cpp
@@ -80,6 +80,7 @@ void Uniform( DistMultiVec<T>& A, Int m, Int n, T center, Base<T> radius )
 #define EL_ENABLE_DOUBLEDOUBLE
 #define EL_ENABLE_QUADDOUBLE
 #define EL_ENABLE_QUAD
+#define EL_ENABLE_BIGINT
 #define EL_ENABLE_BIGFLOAT
 #include "El/macros/Instantiate.h"
 

--- a/src/matrices/Walsh.cpp
+++ b/src/matrices/Walsh.cpp
@@ -87,6 +87,7 @@ void Walsh( AbstractDistMatrix<T>& A, Int k, bool binary )
 #define EL_ENABLE_DOUBLEDOUBLE
 #define EL_ENABLE_QUADDOUBLE
 #define EL_ENABLE_QUAD
+#define EL_ENABLE_BIGINT
 #define EL_ENABLE_BIGFLOAT
 #include "El/macros/Instantiate.h"
 

--- a/src/matrices/WalshIdentity.cpp
+++ b/src/matrices/WalshIdentity.cpp
@@ -48,6 +48,7 @@ void WalshIdentity( ElementalMatrix<T>& A, Int k, bool binary )
 #define EL_ENABLE_DOUBLEDOUBLE
 #define EL_ENABLE_QUADDOUBLE
 #define EL_ENABLE_QUAD
+#define EL_ENABLE_BIGINT
 #define EL_ENABLE_BIGFLOAT
 #include "El/macros/Instantiate.h"
 

--- a/src/matrices/Wilkinson.cpp
+++ b/src/matrices/Wilkinson.cpp
@@ -47,6 +47,7 @@ void Wilkinson( AbstractDistMatrix<T>& A, Int k )
 #define EL_ENABLE_DOUBLEDOUBLE
 #define EL_ENABLE_QUADDOUBLE
 #define EL_ENABLE_QUAD
+#define EL_ENABLE_BIGINT
 #define EL_ENABLE_BIGFLOAT
 #include "El/macros/Instantiate.h"
 

--- a/src/matrices/Zeros.cpp
+++ b/src/matrices/Zeros.cpp
@@ -60,6 +60,7 @@ void Zeros( DistMultiVec<T>& A, Int m, Int n )
 #define EL_ENABLE_DOUBLEDOUBLE
 #define EL_ENABLE_QUADDOUBLE
 #define EL_ENABLE_QUAD
+#define EL_ENABLE_BIGINT
 #define EL_ENABLE_BIGFLOAT
 #include "El/macros/Instantiate.h"
 

--- a/tests/core/DistMatrix.cpp
+++ b/tests/core/DistMatrix.cpp
@@ -58,6 +58,10 @@ Check( DistMatrix<T,AColDist,ARowDist>& A,
     {
         if( commRank == 0 )
             Output("PASSED");
+        if( print )
+            Print( A, "A" );
+        if( print ) 
+            Print( B, "B" );
     }
     else
     {
@@ -79,7 +83,10 @@ void CheckAll( Int m, Int n, const Grid& g, bool print )
     mpi::Broadcast( colAlign, 0, g.Comm() );
     mpi::Broadcast( rowAlign, 0, g.Comm() );
     A.Align( colAlign, rowAlign );
-    Uniform( A, m, n );
+
+    const T center = 0;
+    const Base<T> radius = 5;
+    Uniform( A, m, n, center, radius );
 
     {
       DistMatrix<T,CIRC,CIRC> A_CIRC_CIRC(g);
@@ -196,7 +203,6 @@ main( int argc, char* argv[] )
         const GridOrder order = ( colMajor ? COLUMN_MAJOR : ROW_MAJOR );
         const Grid g( comm, r, order );
 
-/*
         if( commRank == 0 )
             Output("Testing with integers:");
         DistMatrixTest<Int>( m, n, g, print );
@@ -234,7 +240,6 @@ main( int argc, char* argv[] )
             Output("Testing with quad-precision complex:");
         DistMatrixTest<Complex<Quad>>( m, n, g, print );
 #endif
-*/
 
 #ifdef EL_HAVE_MPC
         if( commRank == 0 )

--- a/tests/core/DistMatrix.cpp
+++ b/tests/core/DistMatrix.cpp
@@ -196,6 +196,7 @@ main( int argc, char* argv[] )
         const GridOrder order = ( colMajor ? COLUMN_MAJOR : ROW_MAJOR );
         const Grid g( comm, r, order );
 
+/*
         if( commRank == 0 )
             Output("Testing with integers:");
         DistMatrixTest<Int>( m, n, g, print );
@@ -233,8 +234,17 @@ main( int argc, char* argv[] )
             Output("Testing with quad-precision complex:");
         DistMatrixTest<Complex<Quad>>( m, n, g, print );
 #endif
+*/
 
 #ifdef EL_HAVE_MPC
+        if( commRank == 0 )
+            Output("Testing with BigInt (with default=256-bit precision):");
+        DistMatrixTest<BigInt>( m, n, g, print );
+        mpc::SetMinIntBits( 512 );
+        if( commRank == 0 )
+            Output("Testing with BigInt (with 512-bit precision):");
+        DistMatrixTest<BigInt>( m, n, g, print );
+
         if( commRank == 0 )
             Output("Testing with BigFloat (with default=256-bit precision):");
         DistMatrixTest<BigFloat>( m, n, g, print );


### PR DESCRIPTION
In addition to fixing a bug in the in-place version of `mpi::TaggedSendRecv` for `BigFloat`, this commit adds library-wide support for a new `BigInt` class, which will later be useful for several algebraic number theory routines (especially maintaining unimodular matrices).