### PR TITLE
Fix includes

### DIFF
--- a/include/El/blas_like/level1/Adjoint.hpp
+++ b/include/El/blas_like/level1/Adjoint.hpp
@@ -9,7 +9,19 @@
 #ifndef EL_BLAS_ADJOINT_HPP
 #define EL_BLAS_ADJOINT_HPP
 
+#include <iosfwd>
+
+#include "El/core.hpp"
+#include "El/core/./DistMatrix/Abstract.hpp"
+#include "El/core/./DistMatrix/Block.hpp"
+#include "El/core/./DistMatrix/Element.hpp"
+#include "El/core/Matrix.hpp"
+#include "El/core/environment/decl.hpp"
+
 namespace El {
+
+template <typename T> class DistSparseMatrix;
+template <typename T> class SparseMatrix;
 
 template<typename T>
 void Adjoint( const Matrix<T>& A, Matrix<T>& B )

--- a/include/El/blas_like/level1/AdjointAxpy.hpp
+++ b/include/El/blas_like/level1/AdjointAxpy.hpp
@@ -9,7 +9,17 @@
 #ifndef EL_BLAS_ADJOINTAXPY_HPP
 #define EL_BLAS_ADJOINTAXPY_HPP
 
+#include <iosfwd>
+
+#include "El/core.hpp"
+#include "El/core/./DistMatrix/Element.hpp"
+#include "El/core/Matrix.hpp"
+#include "El/core/environment/decl.hpp"
+
 namespace El {
+
+template <typename T> class DistSparseMatrix;
+template <typename T> class SparseMatrix;
 
 template<typename T,typename S>
 void AdjointAxpy( S alphaS, const Matrix<T>& X, Matrix<T>& Y )

--- a/include/El/blas_like/level1/AdjointAxpyContract.hpp
+++ b/include/El/blas_like/level1/AdjointAxpyContract.hpp
@@ -9,6 +9,13 @@
 #ifndef EL_BLAS_ADJOINTAXPYCONTRACT_HPP
 #define EL_BLAS_ADJOINTAXPYCONTRACT_HPP
 
+#include <iosfwd>
+
+#include "El/core.hpp"
+#include "El/core/./DistMatrix/Block.hpp"
+#include "El/core/./DistMatrix/Element.hpp"
+#include "El/core/environment/decl.hpp"
+
 namespace El {
 
 template<typename T>

--- a/include/El/blas_like/level1/AdjointContract.hpp
+++ b/include/El/blas_like/level1/AdjointContract.hpp
@@ -9,6 +9,13 @@
 #ifndef EL_BLAS_ADJOINTCONTRACT_HPP
 #define EL_BLAS_ADJOINTCONTRACT_HPP
 
+#include <iosfwd>
+
+#include "El/core.hpp"
+#include "El/core/./DistMatrix/Block.hpp"
+#include "El/core/./DistMatrix/Element.hpp"
+#include "El/core/environment/decl.hpp"
+
 namespace El {
 
 template<typename T>

--- a/include/El/blas_like/level1/Axpy.hpp
+++ b/include/El/blas_like/level1/Axpy.hpp
@@ -9,9 +9,25 @@
 #ifndef EL_BLAS_AXPY_HPP
 #define EL_BLAS_AXPY_HPP
 
+#include <iosfwd>
+#include <memory>
+
 #include "./Axpy/util.hpp"
+#include "El/core.hpp"
+#include "El/core/./DistMatrix/Abstract.hpp"
+#include "El/core/./DistMatrix/Block.hpp"
+#include "El/core/./DistMatrix/Element.hpp"
+#include "El/core/Matrix.hpp"
+#include "El/core/environment/decl.hpp"
+#include "El/core/imports/blas.hpp"
+#include "El/core/imports/mpi.hpp"
+#include "El/core/types.hpp"
 
 namespace El {
+
+template <typename T> class DistMultiVec;
+template <typename T> class DistSparseMatrix;
+template <typename T> class SparseMatrix;
 
 template<typename T,typename S>
 void Axpy( S alphaS, const Matrix<T>& X, Matrix<T>& Y )

--- a/include/El/blas_like/level1/AxpyTrapezoid.hpp
+++ b/include/El/blas_like/level1/AxpyTrapezoid.hpp
@@ -9,7 +9,21 @@
 #ifndef EL_BLAS_AXPYTRAPEZOID_HPP
 #define EL_BLAS_AXPYTRAPEZOID_HPP
 
+#include <iosfwd>
+#include <memory>
+
+#include "El/core.hpp"
+#include "El/core/./DistMatrix/Abstract.hpp"
+#include "El/core/./DistMatrix/Element.hpp"
+#include "El/core/Matrix.hpp"
+#include "El/core/environment/decl.hpp"
+#include "El/core/imports/blas.hpp"
+#include "El/core/types.hpp"
+
 namespace El {
+
+template <typename T> class DistSparseMatrix;
+template <typename T> class SparseMatrix;
 
 template<typename T,typename S>
 void AxpyTrapezoid

--- a/include/El/blas_like/level1/Contract.hpp
+++ b/include/El/blas_like/level1/Contract.hpp
@@ -9,6 +9,14 @@
 #ifndef EL_BLAS_CONTRACT_HPP
 #define EL_BLAS_CONTRACT_HPP
 
+#include <iosfwd>
+
+#include "El/core.hpp"
+#include "El/core/./DistMatrix/Block.hpp"
+#include "El/core/./DistMatrix/Element.hpp"
+#include "El/core/environment/decl.hpp"
+#include "El/core/types.hpp"
+
 namespace El {
 
 template<typename T>

--- a/include/El/blas_like/level1/Copy.hpp
+++ b/include/El/blas_like/level1/Copy.hpp
@@ -9,11 +9,31 @@
 #ifndef EL_BLAS_COPY_HPP
 #define EL_BLAS_COPY_HPP
 
-#include "./Copy/internal_decl.hpp"
+#include <functional>
+#include <ostream>
+#include <vector>
+
 #include "./Copy/GeneralPurpose.hpp"
+#include "./Copy/internal_decl.hpp"
 #include "./Copy/util.hpp"
+#include "El/core.hpp"
+#include "El/core/./DistMatrix/Abstract.hpp"
+#include "El/core/./DistMatrix/Block.hpp"
+#include "El/core/./DistMatrix/Element.hpp"
+#include "El/core/Element/decl.hpp"
+#include "El/core/Matrix.hpp"
+#include "El/core/environment/decl.hpp"
+#include "El/core/environment/impl.hpp"
+#include "El/core/imports/lapack.hpp"
+#include "El/core/imports/mpi.hpp"
+#include "El/core/types.hpp"
 
 namespace El {
+
+template <typename T = double, El::DistNS::Dist U = MC, El::DistNS::Dist V = MR, El::DistWrapNS::DistWrap wrap = ELEMENT> class DistMatrix;
+template <typename T> class DistMultiVec;
+template <typename T> class DistSparseMatrix;
+template <typename T> class SparseMatrix;
 
 template<typename T>
 void Copy( const Matrix<T>& A, Matrix<T>& B )

--- a/include/El/blas_like/level1/Copy.hpp
+++ b/include/El/blas_like/level1/Copy.hpp
@@ -30,7 +30,6 @@
 
 namespace El {
 
-template <typename T = double, El::DistNS::Dist U = MC, El::DistNS::Dist V = MR, El::DistWrapNS::DistWrap wrap = ELEMENT> class DistMatrix;
 template <typename T> class DistMultiVec;
 template <typename T> class DistSparseMatrix;
 template <typename T> class SparseMatrix;

--- a/include/El/blas_like/level1/Copy/AllGather.hpp
+++ b/include/El/blas_like/level1/Copy/AllGather.hpp
@@ -12,7 +12,7 @@
 #include <iosfwd>
 #include <vector>
 
-#include "/El/blas_like/level1/Copy/util.hpp"
+#include "El/blas_like/level1/Copy/util.hpp"
 #include "El/core.hpp"
 #include "El/core/environment/decl.hpp"
 #include "El/core/imports/mpi.hpp"
@@ -20,7 +20,6 @@
 #include "El/core/types.hpp"
 
 namespace El {
-template <typename T = double, El::DistNS::Dist U = MC, El::DistNS::Dist V = MR, El::DistWrapNS::DistWrap wrap = ELEMENT> class DistMatrix;
 }  // namespace El
 
 namespace El {

--- a/include/El/blas_like/level1/Copy/AllGather.hpp
+++ b/include/El/blas_like/level1/Copy/AllGather.hpp
@@ -9,6 +9,20 @@
 #ifndef EL_BLAS_COPY_ALLGATHER_HPP
 #define EL_BLAS_COPY_ALLGATHER_HPP
 
+#include <iosfwd>
+#include <vector>
+
+#include "/El/blas_like/level1/Copy/util.hpp"
+#include "El/core.hpp"
+#include "El/core/environment/decl.hpp"
+#include "El/core/imports/mpi.hpp"
+#include "El/core/indexing/impl.hpp"
+#include "El/core/types.hpp"
+
+namespace El {
+template <typename T = double, El::DistNS::Dist U = MC, El::DistNS::Dist V = MR, El::DistWrapNS::DistWrap wrap = ELEMENT> class DistMatrix;
+}  // namespace El
+
 namespace El {
 namespace copy {
 

--- a/include/El/blas_like/level1/Copy/ColAllToAllDemote.hpp
+++ b/include/El/blas_like/level1/Copy/ColAllToAllDemote.hpp
@@ -12,7 +12,7 @@
 #include <iosfwd>
 #include <vector>
 
-#include "/El/blas_like/level1/Copy/util.hpp"
+#include "El/blas_like/level1/Copy/util.hpp"
 #include "El/core.hpp"
 #include "El/core/environment/decl.hpp"
 #include "El/core/imports/mpi.hpp"
@@ -20,7 +20,6 @@
 #include "El/core/types.hpp"
 
 namespace El {
-template <typename T = double, El::DistNS::Dist U = MC, El::DistNS::Dist V = MR, El::DistWrapNS::DistWrap wrap = ELEMENT> class DistMatrix;
 }  // namespace El
 
 namespace El {

--- a/include/El/blas_like/level1/Copy/ColAllToAllDemote.hpp
+++ b/include/El/blas_like/level1/Copy/ColAllToAllDemote.hpp
@@ -9,6 +9,20 @@
 #ifndef EL_BLAS_COPY_COLALLTOALLDEMOTE_HPP
 #define EL_BLAS_COPY_COLALLTOALLDEMOTE_HPP
 
+#include <iosfwd>
+#include <vector>
+
+#include "/El/blas_like/level1/Copy/util.hpp"
+#include "El/core.hpp"
+#include "El/core/environment/decl.hpp"
+#include "El/core/imports/mpi.hpp"
+#include "El/core/indexing/impl.hpp"
+#include "El/core/types.hpp"
+
+namespace El {
+template <typename T = double, El::DistNS::Dist U = MC, El::DistNS::Dist V = MR, El::DistWrapNS::DistWrap wrap = ELEMENT> class DistMatrix;
+}  // namespace El
+
 namespace El {
 namespace copy {
 

--- a/include/El/blas_like/level1/Copy/ColAllToAllPromote.hpp
+++ b/include/El/blas_like/level1/Copy/ColAllToAllPromote.hpp
@@ -12,7 +12,7 @@
 #include <iosfwd>
 #include <vector>
 
-#include "/El/blas_like/level1/Copy/util.hpp"
+#include "El/blas_like/level1/Copy/util.hpp"
 #include "El/core.hpp"
 #include "El/core/environment/decl.hpp"
 #include "El/core/imports/mpi.hpp"
@@ -20,7 +20,6 @@
 #include "El/core/types.hpp"
 
 namespace El {
-template <typename T = double, El::DistNS::Dist U = MC, El::DistNS::Dist V = MR, El::DistWrapNS::DistWrap wrap = ELEMENT> class DistMatrix;
 }  // namespace El
 
 namespace El {

--- a/include/El/blas_like/level1/Copy/ColAllToAllPromote.hpp
+++ b/include/El/blas_like/level1/Copy/ColAllToAllPromote.hpp
@@ -9,6 +9,20 @@
 #ifndef EL_BLAS_COPY_COLALLTOALLPROMOTE_HPP
 #define EL_BLAS_COPY_COLALLTOALLPROMOTE_HPP
 
+#include <iosfwd>
+#include <vector>
+
+#include "/El/blas_like/level1/Copy/util.hpp"
+#include "El/core.hpp"
+#include "El/core/environment/decl.hpp"
+#include "El/core/imports/mpi.hpp"
+#include "El/core/indexing/impl.hpp"
+#include "El/core/types.hpp"
+
+namespace El {
+template <typename T = double, El::DistNS::Dist U = MC, El::DistNS::Dist V = MR, El::DistWrapNS::DistWrap wrap = ELEMENT> class DistMatrix;
+}  // namespace El
+
 namespace El {
 namespace copy {
 

--- a/include/El/blas_like/level1/Copy/Exchange.hpp
+++ b/include/El/blas_like/level1/Copy/Exchange.hpp
@@ -12,7 +12,7 @@
 #include <iosfwd>
 #include <vector>
 
-#include "/El/blas_like/level1/Copy/util.hpp"
+#include "El/blas_like/level1/Copy/util.hpp"
 #include "El/core.hpp"
 #include "El/core/./DistMatrix/Element.hpp"
 #include "El/core/environment/decl.hpp"
@@ -21,7 +21,6 @@
 #include "El/core/types.hpp"
 
 namespace El {
-template <typename T = double, El::DistNS::Dist U = MC, El::DistNS::Dist V = MR, El::DistWrapNS::DistWrap wrap = ELEMENT> class DistMatrix;
 }  // namespace El
 
 namespace El {

--- a/include/El/blas_like/level1/Copy/Exchange.hpp
+++ b/include/El/blas_like/level1/Copy/Exchange.hpp
@@ -9,6 +9,21 @@
 #ifndef EL_BLAS_COPY_EXCHANGE_HPP
 #define EL_BLAS_COPY_EXCHANGE_HPP
 
+#include <iosfwd>
+#include <vector>
+
+#include "/El/blas_like/level1/Copy/util.hpp"
+#include "El/core.hpp"
+#include "El/core/./DistMatrix/Element.hpp"
+#include "El/core/environment/decl.hpp"
+#include "El/core/imports/mpi.hpp"
+#include "El/core/indexing/impl.hpp"
+#include "El/core/types.hpp"
+
+namespace El {
+template <typename T = double, El::DistNS::Dist U = MC, El::DistNS::Dist V = MR, El::DistWrapNS::DistWrap wrap = ELEMENT> class DistMatrix;
+}  // namespace El
+
 namespace El {
 namespace copy {
 

--- a/include/El/blas_like/level1/Copy/Filter.hpp
+++ b/include/El/blas_like/level1/Copy/Filter.hpp
@@ -11,13 +11,12 @@
 
 #include <iosfwd>
 
-#include "/El/blas_like/level1/Copy/util.hpp"
+#include "El/blas_like/level1/Copy/util.hpp"
 #include "El/core.hpp"
 #include "El/core/environment/decl.hpp"
 #include "El/core/types.hpp"
 
 namespace El {
-template <typename T = double, El::DistNS::Dist U = MC, El::DistNS::Dist V = MR, El::DistWrapNS::DistWrap wrap = ELEMENT> class DistMatrix;
 }  // namespace El
 
 namespace El {

--- a/include/El/blas_like/level1/Copy/Filter.hpp
+++ b/include/El/blas_like/level1/Copy/Filter.hpp
@@ -9,6 +9,17 @@
 #ifndef EL_BLAS_COPY_FILTER_HPP
 #define EL_BLAS_COPY_FILTER_HPP
 
+#include <iosfwd>
+
+#include "/El/blas_like/level1/Copy/util.hpp"
+#include "El/core.hpp"
+#include "El/core/environment/decl.hpp"
+#include "El/core/types.hpp"
+
+namespace El {
+template <typename T = double, El::DistNS::Dist U = MC, El::DistNS::Dist V = MR, El::DistWrapNS::DistWrap wrap = ELEMENT> class DistMatrix;
+}  // namespace El
+
 namespace El {
 namespace copy {
 

--- a/include/El/blas_like/level1/Copy/Gather.hpp
+++ b/include/El/blas_like/level1/Copy/Gather.hpp
@@ -9,6 +9,23 @@
 #ifndef EL_BLAS_COPY_GATHER_HPP
 #define EL_BLAS_COPY_GATHER_HPP
 
+#include <iosfwd>
+#include <vector>
+
+#include "/El/blas_like/level1/Copy/util.hpp"
+#include "El/core.hpp"
+#include "El/core/./DistMatrix/Block.hpp"
+#include "El/core/./DistMatrix/Element.hpp"
+#include "El/core/environment/decl.hpp"
+#include "El/core/environment/impl.hpp"
+#include "El/core/imports/mpi.hpp"
+#include "El/core/indexing/impl.hpp"
+#include "El/core/types.hpp"
+
+namespace El {
+template <typename T = double, El::DistNS::Dist U = MC, El::DistNS::Dist V = MR, El::DistWrapNS::DistWrap wrap = ELEMENT> class DistMatrix;
+}  // namespace El
+
 namespace El {
 namespace copy {
 

--- a/include/El/blas_like/level1/Copy/Gather.hpp
+++ b/include/El/blas_like/level1/Copy/Gather.hpp
@@ -12,7 +12,7 @@
 #include <iosfwd>
 #include <vector>
 
-#include "/El/blas_like/level1/Copy/util.hpp"
+#include "El/blas_like/level1/Copy/util.hpp"
 #include "El/core.hpp"
 #include "El/core/./DistMatrix/Block.hpp"
 #include "El/core/./DistMatrix/Element.hpp"
@@ -23,7 +23,6 @@
 #include "El/core/types.hpp"
 
 namespace El {
-template <typename T = double, El::DistNS::Dist U = MC, El::DistNS::Dist V = MR, El::DistWrapNS::DistWrap wrap = ELEMENT> class DistMatrix;
 }  // namespace El
 
 namespace El {

--- a/include/El/blas_like/level1/Copy/GeneralPurpose.hpp
+++ b/include/El/blas_like/level1/Copy/GeneralPurpose.hpp
@@ -9,6 +9,18 @@
 #ifndef EL_BLAS_COPY_GENERALPURPOSE_HPP
 #define EL_BLAS_COPY_GENERALPURPOSE_HPP
 
+#include <iosfwd>
+#include <vector>
+
+#include "El/core.hpp"
+#include "El/core/./DistMatrix/Abstract.hpp"
+#include "El/core/Element/decl.hpp"
+#include "El/core/Grid.hpp"
+#include "El/core/environment/decl.hpp"
+#include "El/core/environment/impl.hpp"
+#include "El/core/imports/mpi.hpp"
+#include "El/core/types.hpp"
+
 namespace El {
 namespace copy {
 

--- a/include/El/blas_like/level1/Copy/PartialRowAllGather.hpp
+++ b/include/El/blas_like/level1/Copy/PartialRowAllGather.hpp
@@ -9,6 +9,18 @@
 #ifndef EL_BLAS_COPY_PARTIALROWALLGATHER_HPP
 #define EL_BLAS_COPY_PARTIALROWALLGATHER_HPP
 
+#include <iosfwd>
+#include <vector>
+
+#include "/El/blas_like/level1/Copy/util.hpp"
+#include "El/core.hpp"
+#include "El/core/./DistMatrix/Block.hpp"
+#include "El/core/./DistMatrix/Element.hpp"
+#include "El/core/environment/decl.hpp"
+#include "El/core/imports/mpi.hpp"
+#include "El/core/indexing/impl.hpp"
+#include "El/core/types.hpp"
+
 namespace El {
 namespace copy {
 

--- a/include/El/blas_like/level1/Copy/PartialRowAllGather.hpp
+++ b/include/El/blas_like/level1/Copy/PartialRowAllGather.hpp
@@ -12,7 +12,7 @@
 #include <iosfwd>
 #include <vector>
 
-#include "/El/blas_like/level1/Copy/util.hpp"
+#include "El/blas_like/level1/Copy/util.hpp"
 #include "El/core.hpp"
 #include "El/core/./DistMatrix/Block.hpp"
 #include "El/core/./DistMatrix/Element.hpp"

--- a/include/El/blas_like/level1/Copy/RowAllGather.hpp
+++ b/include/El/blas_like/level1/Copy/RowAllGather.hpp
@@ -9,6 +9,18 @@
 #ifndef EL_BLAS_COPY_ROWALLGATHER_HPP
 #define EL_BLAS_COPY_ROWALLGATHER_HPP
 
+#include <iosfwd>
+#include <vector>
+
+#include "/El/blas_like/level1/Copy/util.hpp"
+#include "El/core.hpp"
+#include "El/core/./DistMatrix/Block.hpp"
+#include "El/core/./DistMatrix/Element.hpp"
+#include "El/core/environment/decl.hpp"
+#include "El/core/imports/mpi.hpp"
+#include "El/core/indexing/impl.hpp"
+#include "El/core/types.hpp"
+
 namespace El {
 namespace copy {
 

--- a/include/El/blas_like/level1/Copy/RowAllGather.hpp
+++ b/include/El/blas_like/level1/Copy/RowAllGather.hpp
@@ -12,7 +12,7 @@
 #include <iosfwd>
 #include <vector>
 
-#include "/El/blas_like/level1/Copy/util.hpp"
+#include "El/blas_like/level1/Copy/util.hpp"
 #include "El/core.hpp"
 #include "El/core/./DistMatrix/Block.hpp"
 #include "El/core/./DistMatrix/Element.hpp"

--- a/include/El/blas_like/level1/Copy/RowAllToAllDemote.hpp
+++ b/include/El/blas_like/level1/Copy/RowAllToAllDemote.hpp
@@ -12,7 +12,7 @@
 #include <iosfwd>
 #include <vector>
 
-#include "/El/blas_like/level1/Copy/util.hpp"
+#include "El/blas_like/level1/Copy/util.hpp"
 #include "El/core.hpp"
 #include "El/core/environment/decl.hpp"
 #include "El/core/imports/mpi.hpp"
@@ -20,7 +20,6 @@
 #include "El/core/types.hpp"
 
 namespace El {
-template <typename T = double, El::DistNS::Dist U = MC, El::DistNS::Dist V = MR, El::DistWrapNS::DistWrap wrap = ELEMENT> class DistMatrix;
 }  // namespace El
 
 namespace El {

--- a/include/El/blas_like/level1/Copy/RowAllToAllDemote.hpp
+++ b/include/El/blas_like/level1/Copy/RowAllToAllDemote.hpp
@@ -9,6 +9,20 @@
 #ifndef EL_BLAS_COPY_ROWALLTOALLDEMOTE_HPP
 #define EL_BLAS_COPY_ROWALLTOALLDEMOTE_HPP
 
+#include <iosfwd>
+#include <vector>
+
+#include "/El/blas_like/level1/Copy/util.hpp"
+#include "El/core.hpp"
+#include "El/core/environment/decl.hpp"
+#include "El/core/imports/mpi.hpp"
+#include "El/core/indexing/impl.hpp"
+#include "El/core/types.hpp"
+
+namespace El {
+template <typename T = double, El::DistNS::Dist U = MC, El::DistNS::Dist V = MR, El::DistWrapNS::DistWrap wrap = ELEMENT> class DistMatrix;
+}  // namespace El
+
 namespace El {
 namespace copy {
 

--- a/include/El/blas_like/level1/Copy/RowAllToAllPromote.hpp
+++ b/include/El/blas_like/level1/Copy/RowAllToAllPromote.hpp
@@ -12,7 +12,7 @@
 #include <iosfwd>
 #include <vector>
 
-#include "/El/blas_like/level1/Copy/util.hpp"
+#include "El/blas_like/level1/Copy/util.hpp"
 #include "El/core.hpp"
 #include "El/core/environment/decl.hpp"
 #include "El/core/imports/mpi.hpp"
@@ -20,7 +20,6 @@
 #include "El/core/types.hpp"
 
 namespace El {
-template <typename T = double, El::DistNS::Dist U = MC, El::DistNS::Dist V = MR, El::DistWrapNS::DistWrap wrap = ELEMENT> class DistMatrix;
 }  // namespace El
 
 namespace El {

--- a/include/El/blas_like/level1/Copy/RowAllToAllPromote.hpp
+++ b/include/El/blas_like/level1/Copy/RowAllToAllPromote.hpp
@@ -9,6 +9,20 @@
 #ifndef EL_BLAS_COPY_ROWALLTOALLPROMOTE_HPP
 #define EL_BLAS_COPY_ROWALLTOALLPROMOTE_HPP
 
+#include <iosfwd>
+#include <vector>
+
+#include "/El/blas_like/level1/Copy/util.hpp"
+#include "El/core.hpp"
+#include "El/core/environment/decl.hpp"
+#include "El/core/imports/mpi.hpp"
+#include "El/core/indexing/impl.hpp"
+#include "El/core/types.hpp"
+
+namespace El {
+template <typename T = double, El::DistNS::Dist U = MC, El::DistNS::Dist V = MR, El::DistWrapNS::DistWrap wrap = ELEMENT> class DistMatrix;
+}  // namespace El
+
 namespace El {
 namespace copy {
 

--- a/include/El/blas_like/level1/Copy/Scatter.hpp
+++ b/include/El/blas_like/level1/Copy/Scatter.hpp
@@ -9,6 +9,22 @@
 #ifndef EL_BLAS_COPY_SCATTER_HPP
 #define EL_BLAS_COPY_SCATTER_HPP
 
+#include <iosfwd>
+#include <vector>
+
+#include "/El/blas_like/level1/Copy/util.hpp"
+#include "El/core.hpp"
+#include "El/core/./DistMatrix/Block.hpp"
+#include "El/core/./DistMatrix/Element.hpp"
+#include "El/core/environment/decl.hpp"
+#include "El/core/imports/mpi.hpp"
+#include "El/core/indexing/impl.hpp"
+#include "El/core/types.hpp"
+
+namespace El {
+template <typename T = double, El::DistNS::Dist U = MC, El::DistNS::Dist V = MR, El::DistWrapNS::DistWrap wrap = ELEMENT> class DistMatrix;
+}  // namespace El
+
 namespace El {
 namespace copy {
 

--- a/include/El/blas_like/level1/Copy/Scatter.hpp
+++ b/include/El/blas_like/level1/Copy/Scatter.hpp
@@ -12,7 +12,7 @@
 #include <iosfwd>
 #include <vector>
 
-#include "/El/blas_like/level1/Copy/util.hpp"
+#include "El/blas_like/level1/Copy/util.hpp"
 #include "El/core.hpp"
 #include "El/core/./DistMatrix/Block.hpp"
 #include "El/core/./DistMatrix/Element.hpp"
@@ -22,7 +22,6 @@
 #include "El/core/types.hpp"
 
 namespace El {
-template <typename T = double, El::DistNS::Dist U = MC, El::DistNS::Dist V = MR, El::DistWrapNS::DistWrap wrap = ELEMENT> class DistMatrix;
 }  // namespace El
 
 namespace El {

--- a/include/El/blas_like/level1/Copy/Translate.hpp
+++ b/include/El/blas_like/level1/Copy/Translate.hpp
@@ -9,6 +9,21 @@
 #ifndef EL_BLAS_COPY_TRANSLATE_HPP
 #define EL_BLAS_COPY_TRANSLATE_HPP
 
+#include <iosfwd>
+#include <vector>
+
+#include "/El/blas_like/level1/Copy/util.hpp"
+#include "El/core.hpp"
+#include "El/core/Grid.hpp"
+#include "El/core/environment/decl.hpp"
+#include "El/core/imports/mpi.hpp"
+#include "El/core/indexing/impl.hpp"
+#include "El/core/types.hpp"
+
+namespace El {
+template <typename T = double, El::DistNS::Dist U = MC, El::DistNS::Dist V = MR, El::DistWrapNS::DistWrap wrap = ELEMENT> class DistMatrix;
+}  // namespace El
+
 namespace El {
 namespace copy {
 

--- a/include/El/blas_like/level1/Copy/Translate.hpp
+++ b/include/El/blas_like/level1/Copy/Translate.hpp
@@ -12,7 +12,7 @@
 #include <iosfwd>
 #include <vector>
 
-#include "/El/blas_like/level1/Copy/util.hpp"
+#include "El/blas_like/level1/Copy/util.hpp"
 #include "El/core.hpp"
 #include "El/core/Grid.hpp"
 #include "El/core/environment/decl.hpp"
@@ -21,7 +21,6 @@
 #include "El/core/types.hpp"
 
 namespace El {
-template <typename T = double, El::DistNS::Dist U = MC, El::DistNS::Dist V = MR, El::DistWrapNS::DistWrap wrap = ELEMENT> class DistMatrix;
 }  // namespace El
 
 namespace El {

--- a/include/El/blas_like/level1/Copy/TranslateBetweenGrids.hpp
+++ b/include/El/blas_like/level1/Copy/TranslateBetweenGrids.hpp
@@ -12,7 +12,7 @@
 #include <iosfwd>
 #include <vector>
 
-#include "/El/blas_like/level1/Copy/util.hpp"
+#include "El/blas_like/level1/Copy/util.hpp"
 #include "El/core.hpp"
 #include "El/core/environment/decl.hpp"
 #include "El/core/imports/mpi.hpp"
@@ -20,7 +20,6 @@
 #include "El/core/types.hpp"
 
 namespace El {
-template <typename T = double, El::DistNS::Dist U = MC, El::DistNS::Dist V = MR, El::DistWrapNS::DistWrap wrap = ELEMENT> class DistMatrix;
 }  // namespace El
 
 namespace El {

--- a/include/El/blas_like/level1/Copy/TranslateBetweenGrids.hpp
+++ b/include/El/blas_like/level1/Copy/TranslateBetweenGrids.hpp
@@ -9,6 +9,20 @@
 #ifndef EL_BLAS_COPY_TRANSLATEBETWEENGRIDS_HPP
 #define EL_BLAS_COPY_TRANSLATEBETWEENGRIDS_HPP
 
+#include <iosfwd>
+#include <vector>
+
+#include "/El/blas_like/level1/Copy/util.hpp"
+#include "El/core.hpp"
+#include "El/core/environment/decl.hpp"
+#include "El/core/imports/mpi.hpp"
+#include "El/core/indexing/impl.hpp"
+#include "El/core/types.hpp"
+
+namespace El {
+template <typename T = double, El::DistNS::Dist U = MC, El::DistNS::Dist V = MR, El::DistWrapNS::DistWrap wrap = ELEMENT> class DistMatrix;
+}  // namespace El
+
 namespace El {
 namespace copy {
 

--- a/include/El/blas_like/level1/Copy/TransposeDist.hpp
+++ b/include/El/blas_like/level1/Copy/TransposeDist.hpp
@@ -21,7 +21,6 @@
 
 namespace El {
 class Grid;
-template <typename T = double, El::DistNS::Dist U = MC, El::DistNS::Dist V = MR, El::DistWrapNS::DistWrap wrap = ELEMENT> class DistMatrix;
 }  // namespace El
 
 namespace El {

--- a/include/El/blas_like/level1/Copy/TransposeDist.hpp
+++ b/include/El/blas_like/level1/Copy/TransposeDist.hpp
@@ -9,6 +9,21 @@
 #ifndef EL_BLAS_COPY_TRANSPOSEDIST_HPP
 #define EL_BLAS_COPY_TRANSPOSEDIST_HPP
 
+#include <iosfwd>
+#include <vector>
+
+#include "El/core.hpp"
+#include "El/core/environment/decl.hpp"
+#include "El/core/imports/mpi.hpp"
+#include "El/core/imports/omp.hpp"
+#include "El/core/indexing/impl.hpp"
+#include "El/core/types.hpp"
+
+namespace El {
+class Grid;
+template <typename T = double, El::DistNS::Dist U = MC, El::DistNS::Dist V = MR, El::DistWrapNS::DistWrap wrap = ELEMENT> class DistMatrix;
+}  // namespace El
+
 namespace El {
 namespace copy {
 

--- a/include/El/blas_like/level1/Copy/internal_decl.hpp
+++ b/include/El/blas_like/level1/Copy/internal_decl.hpp
@@ -9,6 +9,17 @@
 #ifndef EL_BLAS1_COPYINTERNAL_DECL_HPP
 #define EL_BLAS1_COPYINTERNAL_DECL_HPP
 
+#include "El/core/./DistMatrix/Abstract.hpp"
+#include "El/core/./DistMatrix/Block.hpp"
+#include "El/core/./DistMatrix/Element.hpp"
+#include "El/core/Element/decl.hpp"
+#include "El/core/imports/mpi.hpp"
+#include "El/core/types.hpp"
+
+namespace El {
+template <typename T = double, El::DistNS::Dist U = MC, El::DistNS::Dist V = MR, El::DistWrapNS::DistWrap wrap = ELEMENT> class DistMatrix;
+}  // namespace El
+
 namespace El {
 
 namespace copy {

--- a/include/El/blas_like/level1/Copy/internal_decl.hpp
+++ b/include/El/blas_like/level1/Copy/internal_decl.hpp
@@ -17,7 +17,6 @@
 #include "El/core/types.hpp"
 
 namespace El {
-template <typename T = double, El::DistNS::Dist U = MC, El::DistNS::Dist V = MR, El::DistWrapNS::DistWrap wrap = ELEMENT> class DistMatrix;
 }  // namespace El
 
 namespace El {

--- a/include/El/blas_like/level1/Copy/internal_impl.hpp
+++ b/include/El/blas_like/level1/Copy/internal_impl.hpp
@@ -17,7 +17,6 @@
 #include "./Exchange.hpp"
 #include "./Filter.hpp"
 #include "./Gather.hpp"
-
 #include "./PartialColAllGather.hpp"
 #include "./PartialColFilter.hpp"
 #include "./PartialRowAllGather.hpp"
@@ -27,8 +26,8 @@
 #include "./RowAllToAllPromote.hpp"
 #include "./RowFilter.hpp"
 #include "./Scatter.hpp"
-#include "./TranslateBetweenGrids.hpp"
 #include "./Translate.hpp"
+#include "./TranslateBetweenGrids.hpp"
 #include "./TransposeDist.hpp"
 
 #endif // ifndef EL_BLAS1_COPY_INTERNAL_IMPL_HPP

--- a/include/El/blas_like/level1/DiagonalScale.hpp
+++ b/include/El/blas_like/level1/DiagonalScale.hpp
@@ -9,7 +9,24 @@
 #ifndef EL_BLAS_DIAGONALSCALE_HPP
 #define EL_BLAS_DIAGONALSCALE_HPP
 
+#include <iosfwd>
+#include <vector>
+
+#include "El/core.hpp"
+#include "El/core/./DistMatrix/Element.hpp"
+#include "El/core/Element/impl.hpp"
+#include "El/core/Matrix.hpp"
+#include "El/core/Proxy.hpp"
+#include "El/core/environment/decl.hpp"
+#include "El/core/imports/mpi.hpp"
+#include "El/core/types.hpp"
+
 namespace El {
+
+template <typename T = double, El::DistNS::Dist U = MC, El::DistNS::Dist V = MR, El::DistWrapNS::DistWrap wrap = ELEMENT> class DistMatrix;
+template <typename T> class DistMultiVec;
+template <typename T> class DistSparseMatrix;
+template <typename T> class SparseMatrix;
 
 template<typename TDiag,typename T>
 void DiagonalScale

--- a/include/El/blas_like/level1/DiagonalScale.hpp
+++ b/include/El/blas_like/level1/DiagonalScale.hpp
@@ -23,7 +23,6 @@
 
 namespace El {
 
-template <typename T = double, El::DistNS::Dist U = MC, El::DistNS::Dist V = MR, El::DistWrapNS::DistWrap wrap = ELEMENT> class DistMatrix;
 template <typename T> class DistMultiVec;
 template <typename T> class DistSparseMatrix;
 template <typename T> class SparseMatrix;

--- a/include/El/blas_like/level1/DiagonalScaleTrapezoid.hpp
+++ b/include/El/blas_like/level1/DiagonalScaleTrapezoid.hpp
@@ -9,7 +9,23 @@
 #ifndef EL_BLAS_DIAGONALSCALETRAPEZOID_HPP
 #define EL_BLAS_DIAGONALSCALETRAPEZOID_HPP
 
+#include <iosfwd>
+
+#include "El/core.hpp"
+#include "El/core/./DistMatrix/Element.hpp"
+#include "El/core/Element/impl.hpp"
+#include "El/core/Matrix.hpp"
+#include "El/core/Proxy.hpp"
+#include "El/core/environment/decl.hpp"
+#include "El/core/imports/blas.hpp"
+#include "El/core/types.hpp"
+
 namespace El {
+
+template <typename T = double, El::DistNS::Dist U = MC, El::DistNS::Dist V = MR, El::DistWrapNS::DistWrap wrap = ELEMENT> class DistMatrix;
+template <typename T> class DistMultiVec;
+template <typename T> class DistSparseMatrix;
+template <typename T> class SparseMatrix;
 
 template<typename TDiag,typename T>
 void DiagonalScaleTrapezoid

--- a/include/El/blas_like/level1/DiagonalScaleTrapezoid.hpp
+++ b/include/El/blas_like/level1/DiagonalScaleTrapezoid.hpp
@@ -22,7 +22,6 @@
 
 namespace El {
 
-template <typename T = double, El::DistNS::Dist U = MC, El::DistNS::Dist V = MR, El::DistWrapNS::DistWrap wrap = ELEMENT> class DistMatrix;
 template <typename T> class DistMultiVec;
 template <typename T> class DistSparseMatrix;
 template <typename T> class SparseMatrix;

--- a/include/El/blas_like/level1/DiagonalSolve.hpp
+++ b/include/El/blas_like/level1/DiagonalSolve.hpp
@@ -24,7 +24,6 @@
 
 namespace El {
 
-template <typename T = double, El::DistNS::Dist U = MC, El::DistNS::Dist V = MR, El::DistWrapNS::DistWrap wrap = ELEMENT> class DistMatrix;
 template <typename T> class DistMultiVec;
 template <typename T> class DistSparseMatrix;
 template <typename T> class SparseMatrix;

--- a/include/El/blas_like/level1/DiagonalSolve.hpp
+++ b/include/El/blas_like/level1/DiagonalSolve.hpp
@@ -9,7 +9,25 @@
 #ifndef EL_BLAS_DIAGONALSOLVE_HPP
 #define EL_BLAS_DIAGONALSOLVE_HPP
 
+#include <iosfwd>
+#include <vector>
+
+#include "El/core.hpp"
+#include "El/core/./DistMatrix/Element.hpp"
+#include "El/core/Element/decl.hpp"
+#include "El/core/Element/impl.hpp"
+#include "El/core/Matrix.hpp"
+#include "El/core/Proxy.hpp"
+#include "El/core/environment/decl.hpp"
+#include "El/core/imports/mpi.hpp"
+#include "El/core/types.hpp"
+
 namespace El {
+
+template <typename T = double, El::DistNS::Dist U = MC, El::DistNS::Dist V = MR, El::DistWrapNS::DistWrap wrap = ELEMENT> class DistMatrix;
+template <typename T> class DistMultiVec;
+template <typename T> class DistSparseMatrix;
+template <typename T> class SparseMatrix;
 
 template<typename FDiag,typename F>
 void DiagonalSolve

--- a/include/El/blas_like/level1/Dot.hpp
+++ b/include/El/blas_like/level1/Dot.hpp
@@ -9,7 +9,16 @@
 #ifndef EL_BLAS_DOT_HPP
 #define EL_BLAS_DOT_HPP
 
+#include <iosfwd>
+
+#include "El/core.hpp"
+#include "El/core/./DistMatrix/Element.hpp"
+#include "El/core/Matrix.hpp"
+#include "El/core/environment/decl.hpp"
+
 namespace El {
+
+template <typename T> class DistMultiVec;
 
 template<typename T> 
 T Dot( const Matrix<T>& A, const Matrix<T>& B )

--- a/include/El/blas_like/level1/Dotu.hpp
+++ b/include/El/blas_like/level1/Dotu.hpp
@@ -9,9 +9,19 @@
 #ifndef EL_BLAS_DOTU_HPP
 #define EL_BLAS_DOTU_HPP
 
+#include <ostream>
+
+#include "El/core.hpp"
+#include "El/core/./DistMatrix/Element.hpp"
+#include "El/core/Matrix.hpp"
+#include "El/core/environment/decl.hpp"
+#include "El/core/imports/mpi.hpp"
+
 namespace El {
 
 // TODO: Think about using a more stable accumulation algorithm?
+
+template <typename T> class DistMultiVec;
 
 template<typename T> 
 T Dotu( const Matrix<T>& A, const Matrix<T>& B )

--- a/include/El/blas_like/level1/EntrywiseFill.hpp
+++ b/include/El/blas_like/level1/EntrywiseFill.hpp
@@ -9,7 +9,18 @@
 #ifndef EL_BLAS_ENTRYWISEFILL_HPP
 #define EL_BLAS_ENTRYWISEFILL_HPP
 
+#include <functional>
+#include <iosfwd>
+
+#include "El/core.hpp"
+#include "El/core/./DistMatrix/Abstract.hpp"
+#include "El/core/Matrix.hpp"
+#include "El/core/environment/decl.hpp"
+#include "El/core/imports/mpi.hpp"
+
 namespace El {
+
+template <typename T> class DistMultiVec;
 
 template<typename T>
 void EntrywiseFill( Matrix<T>& A, function<T(void)> func )

--- a/include/El/blas_like/level1/EntrywiseMap.hpp
+++ b/include/El/blas_like/level1/EntrywiseMap.hpp
@@ -9,7 +9,23 @@
 #ifndef EL_BLAS_ENTRYWISEMAP_HPP
 #define EL_BLAS_ENTRYWISEMAP_HPP
 
+#include <functional>
+#include <iosfwd>
+
+#include "El/core.hpp"
+#include "El/core/./DistMatrix/Abstract.hpp"
+#include "El/core/./DistMatrix/Block.hpp"
+#include "El/core/./DistMatrix/Element.hpp"
+#include "El/core/Matrix.hpp"
+#include "El/core/environment/decl.hpp"
+#include "El/core/imports/mpi.hpp"
+#include "El/core/types.hpp"
+
 namespace El {
+
+template <typename T> class DistMultiVec;
+template <typename T> class DistSparseMatrix;
+template <typename T> class SparseMatrix;
 
 template<typename T>
 void EntrywiseMap( Matrix<T>& A, function<T(T)> func )
@@ -106,6 +122,7 @@ void EntrywiseMap
           Copy( A, AProx ); \
           EntrywiseMap( AProx.Matrix(), B.Matrix(), func );
         #include "El/macros/GuardAndPayload.h"
+
         #undef GUARD
         #undef PAYLOAD
     }
@@ -134,6 +151,7 @@ void EntrywiseMap
           Copy( A, AProx ); \
           EntrywiseMap( AProx.Matrix(), B.Matrix(), func );
         #include "El/macros/GuardAndPayload.h"
+
         #undef GUARD
         #undef PAYLOAD
     }

--- a/include/El/blas_like/level1/FillDiagonal.hpp
+++ b/include/El/blas_like/level1/FillDiagonal.hpp
@@ -9,6 +9,13 @@
 #ifndef EL_BLAS_FILLDIAGONAL_HPP
 #define EL_BLAS_FILLDIAGONAL_HPP
 
+#include <iosfwd>
+
+#include "El/core.hpp"
+#include "El/core/./DistMatrix/Abstract.hpp"
+#include "El/core/Matrix.hpp"
+#include "El/core/environment/decl.hpp"
+
 namespace El {
 
 template<typename T>

--- a/include/El/blas_like/level1/GetDiagonal.hpp
+++ b/include/El/blas_like/level1/GetDiagonal.hpp
@@ -9,7 +9,21 @@
 #ifndef EL_BLAS_GETDIAGONAL_HPP
 #define EL_BLAS_GETDIAGONAL_HPP
 
+#include <functional>
+#include <iosfwd>
+
+#include "El/core.hpp"
+#include "El/core/./DistMatrix/Element.hpp"
+#include "El/core/Element/decl.hpp"
+#include "El/core/Element/impl.hpp"
+#include "El/core/Matrix.hpp"
+#include "El/core/environment/decl.hpp"
+#include "El/core/imports/mpi.hpp"
+#include "El/core/types.hpp"
+
 namespace El {
+
+template <typename T = double, El::DistNS::Dist U = MC, El::DistNS::Dist V = MR, El::DistWrapNS::DistWrap wrap = ELEMENT> class DistMatrix;
 
 template<typename T>
 void GetDiagonal( const Matrix<T>& A, Matrix<T>& d, Int offset )

--- a/include/El/blas_like/level1/GetDiagonal.hpp
+++ b/include/El/blas_like/level1/GetDiagonal.hpp
@@ -23,7 +23,6 @@
 
 namespace El {
 
-template <typename T = double, El::DistNS::Dist U = MC, El::DistNS::Dist V = MR, El::DistWrapNS::DistWrap wrap = ELEMENT> class DistMatrix;
 
 template<typename T>
 void GetDiagonal( const Matrix<T>& A, Matrix<T>& d, Int offset )

--- a/include/El/blas_like/level1/GetMappedDiagonal.hpp
+++ b/include/El/blas_like/level1/GetMappedDiagonal.hpp
@@ -25,7 +25,6 @@
 
 namespace El {
 
-template <typename T = double, El::DistNS::Dist U = MC, El::DistNS::Dist V = MR, El::DistWrapNS::DistWrap wrap = ELEMENT> class DistMatrix;
 template <typename T> class DistMultiVec;
 template <typename T> class DistSparseMatrix;
 template <typename T> class SparseMatrix;

--- a/include/El/blas_like/level1/GetMappedDiagonal.hpp
+++ b/include/El/blas_like/level1/GetMappedDiagonal.hpp
@@ -9,7 +9,26 @@
 #ifndef EL_BLAS_GETMAPPEDDIAGONAL_HPP
 #define EL_BLAS_GETMAPPEDDIAGONAL_HPP
 
+#include <algorithm>
+#include <functional>
+#include <iosfwd>
+
+#include "El/core.hpp"
+#include "El/core/./DistMatrix/Element.hpp"
+#include "El/core/Matrix.hpp"
+#include "El/core/Proxy.hpp"
+#include "El/core/environment/decl.hpp"
+#include "El/core/imports/mpi.hpp"
+#include "El/core/imports/omp.hpp"
+#include "El/core/indexing/impl.hpp"
+#include "El/core/types.hpp"
+
 namespace El {
+
+template <typename T = double, El::DistNS::Dist U = MC, El::DistNS::Dist V = MR, El::DistWrapNS::DistWrap wrap = ELEMENT> class DistMatrix;
+template <typename T> class DistMultiVec;
+template <typename T> class DistSparseMatrix;
+template <typename T> class SparseMatrix;
 
 template<typename T,typename S>
 void GetMappedDiagonal

--- a/include/El/blas_like/level1/GetSubmatrix.hpp
+++ b/include/El/blas_like/level1/GetSubmatrix.hpp
@@ -9,10 +9,28 @@
 #ifndef EL_BLAS_GETSUBMATRIX_HPP
 #define EL_BLAS_GETSUBMATRIX_HPP
 
+#include <iosfwd>
+#include <memory>
+#include <vector>
+
+#include "El/core.hpp"
+#include "El/core/./DistMatrix/Abstract.hpp"
+#include "El/core/./DistMatrix/Element.hpp"
+#include "El/core/Matrix.hpp"
+#include "El/core/View.hpp"
+#include "El/core/environment/decl.hpp"
+#include "El/core/environment/impl.hpp"
+#include "El/core/types.hpp"
+
 namespace El {
 
 // Contiguous
 // ==========
+class Grid;
+template <typename T> class DistMultiVec;
+template <typename T> class DistSparseMatrix;
+template <typename T> class SparseMatrix;
+
 template<typename T>
 void GetSubmatrix
 ( const Matrix<T>& A,

--- a/include/El/blas_like/level1/IndexDependentFill.hpp
+++ b/include/El/blas_like/level1/IndexDependentFill.hpp
@@ -9,6 +9,15 @@
 #ifndef EL_BLAS_INDEXDEPENDENTFILL_HPP
 #define EL_BLAS_INDEXDEPENDENTFILL_HPP
 
+#include <functional>
+#include <iosfwd>
+
+#include "El/core.hpp"
+#include "El/core/./DistMatrix/Abstract.hpp"
+#include "El/core/Matrix.hpp"
+#include "El/core/environment/decl.hpp"
+#include "El/core/imports/mpi.hpp"
+
 namespace El {
 
 template<typename T>

--- a/include/El/blas_like/level1/IndexDependentMap.hpp
+++ b/include/El/blas_like/level1/IndexDependentMap.hpp
@@ -9,6 +9,17 @@
 #ifndef EL_BLAS_INDEXDEPENDENTMAP_HPP
 #define EL_BLAS_INDEXDEPENDENTMAP_HPP
 
+#include <functional>
+#include <iosfwd>
+
+#include "El/core.hpp"
+#include "El/core/./DistMatrix/Abstract.hpp"
+#include "El/core/./DistMatrix/Block.hpp"
+#include "El/core/./DistMatrix/Element.hpp"
+#include "El/core/Matrix.hpp"
+#include "El/core/environment/decl.hpp"
+#include "El/core/imports/mpi.hpp"
+
 namespace El {
 
 template<typename T>

--- a/include/El/blas_like/level1/QuasiDiagonalScale.hpp
+++ b/include/El/blas_like/level1/QuasiDiagonalScale.hpp
@@ -9,7 +9,21 @@
 #ifndef EL_BLAS_QUASIDIAGONALSCALE_HPP
 #define EL_BLAS_QUASIDIAGONALSCALE_HPP
 
+#include <iosfwd>
+
+#include "El/core.hpp"
+#include "El/core/./DistMatrix/Element.hpp"
+#include "El/core/Element/impl.hpp"
+#include "El/core/Matrix.hpp"
+#include "El/core/View.hpp"
+#include "El/core/environment/decl.hpp"
+#include "El/core/indexing/impl.hpp"
+#include "El/core/types.hpp"
+
 namespace El {
+
+class Grid;
+template <typename T = double, El::DistNS::Dist U = MC, El::DistNS::Dist V = MR, El::DistWrapNS::DistWrap wrap = ELEMENT> class DistMatrix;
 
 template<typename F,typename FMain>
 void QuasiDiagonalScale

--- a/include/El/blas_like/level1/QuasiDiagonalScale.hpp
+++ b/include/El/blas_like/level1/QuasiDiagonalScale.hpp
@@ -23,7 +23,6 @@
 namespace El {
 
 class Grid;
-template <typename T = double, El::DistNS::Dist U = MC, El::DistNS::Dist V = MR, El::DistWrapNS::DistWrap wrap = ELEMENT> class DistMatrix;
 
 template<typename F,typename FMain>
 void QuasiDiagonalScale

--- a/include/El/blas_like/level1/QuasiDiagonalSolve.hpp
+++ b/include/El/blas_like/level1/QuasiDiagonalSolve.hpp
@@ -24,7 +24,6 @@ namespace El {
 // TODO: Avoid duplication with QuasiDiagonalScale if possible. Only
 //       difference is the inversions
 class Grid;
-template <typename T = double, El::DistNS::Dist U = MC, El::DistNS::Dist V = MR, El::DistWrapNS::DistWrap wrap = ELEMENT> class DistMatrix;
 
 template<typename F,typename FMain>
 void

--- a/include/El/blas_like/level1/QuasiDiagonalSolve.hpp
+++ b/include/El/blas_like/level1/QuasiDiagonalSolve.hpp
@@ -9,10 +9,23 @@
 #ifndef EL_BLAS_QUASIDIAGONALSOLVE_HPP
 #define EL_BLAS_QUASIDIAGONALSOLVE_HPP
 
+#include <iosfwd>
+
+#include "El/core.hpp"
+#include "El/core/./DistMatrix/Element.hpp"
+#include "El/core/Element/impl.hpp"
+#include "El/core/Matrix.hpp"
+#include "El/core/environment/decl.hpp"
+#include "El/core/indexing/impl.hpp"
+#include "El/core/types.hpp"
+
 namespace El {
 
 // TODO: Avoid duplication with QuasiDiagonalScale if possible. Only
 //       difference is the inversions
+class Grid;
+template <typename T = double, El::DistNS::Dist U = MC, El::DistNS::Dist V = MR, El::DistWrapNS::DistWrap wrap = ELEMENT> class DistMatrix;
+
 template<typename F,typename FMain>
 void
 QuasiDiagonalSolve

--- a/include/El/blas_like/level1/Scale.hpp
+++ b/include/El/blas_like/level1/Scale.hpp
@@ -9,7 +9,22 @@
 #ifndef EL_BLAS_SCALE_HPP
 #define EL_BLAS_SCALE_HPP
 
+#include <iosfwd>
+#include <vector>
+
+#include "El/core.hpp"
+#include "El/core/./DistMatrix/Abstract.hpp"
+#include "El/core/Element/decl.hpp"
+#include "El/core/Matrix.hpp"
+#include "El/core/environment/decl.hpp"
+#include "El/core/imports/blas.hpp"
+#include "El/core/imports/mpi.hpp"
+
 namespace El {
+
+template <typename T> class DistMultiVec;
+template <typename T> class DistSparseMatrix;
+template <typename T> class SparseMatrix;
 
 template<typename T,typename S>
 void Scale( S alphaS, Matrix<T>& A )

--- a/include/El/blas_like/level1/ScaleTrapezoid.hpp
+++ b/include/El/blas_like/level1/ScaleTrapezoid.hpp
@@ -9,7 +9,19 @@
 #ifndef EL_BLAS_SCALETRAPEZOID_HPP
 #define EL_BLAS_SCALETRAPEZOID_HPP
 
+#include <iosfwd>
+
+#include "El/core.hpp"
+#include "El/core/./DistMatrix/Abstract.hpp"
+#include "El/core/Matrix.hpp"
+#include "El/core/environment/decl.hpp"
+#include "El/core/imports/omp.hpp"
+#include "El/core/types.hpp"
+
 namespace El {
+
+template <typename T> class DistSparseMatrix;
+template <typename T> class SparseMatrix;
 
 template<typename T,typename S>
 void ScaleTrapezoid( S alphaS, UpperOrLower uplo, Matrix<T>& A, Int offset )

--- a/include/El/blas_like/level1/SetDiagonal.hpp
+++ b/include/El/blas_like/level1/SetDiagonal.hpp
@@ -9,7 +9,21 @@
 #ifndef EL_BLAS_SETDIAGONAL_HPP
 #define EL_BLAS_SETDIAGONAL_HPP
 
+#include <functional>
+#include <iosfwd>
+
+#include "El/core.hpp"
+#include "El/core/./DistMatrix/Element.hpp"
+#include "El/core/Element/decl.hpp"
+#include "El/core/Element/impl.hpp"
+#include "El/core/Matrix.hpp"
+#include "El/core/environment/decl.hpp"
+#include "El/core/imports/mpi.hpp"
+#include "El/core/types.hpp"
+
 namespace El {
+
+template <typename T = double, El::DistNS::Dist U = MC, El::DistNS::Dist V = MR, El::DistWrapNS::DistWrap wrap = ELEMENT> class DistMatrix;
 
 template<typename T>
 void SetDiagonal( Matrix<T>& A, const Matrix<T>& d, Int offset )

--- a/include/El/blas_like/level1/SetDiagonal.hpp
+++ b/include/El/blas_like/level1/SetDiagonal.hpp
@@ -23,7 +23,6 @@
 
 namespace El {
 
-template <typename T = double, El::DistNS::Dist U = MC, El::DistNS::Dist V = MR, El::DistWrapNS::DistWrap wrap = ELEMENT> class DistMatrix;
 
 template<typename T>
 void SetDiagonal( Matrix<T>& A, const Matrix<T>& d, Int offset )

--- a/include/El/blas_like/level1/Shift.hpp
+++ b/include/El/blas_like/level1/Shift.hpp
@@ -9,7 +9,16 @@
 #ifndef EL_BLAS_SHIFT_HPP
 #define EL_BLAS_SHIFT_HPP
 
+#include <iosfwd>
+
+#include "El/core.hpp"
+#include "El/core/./DistMatrix/Abstract.hpp"
+#include "El/core/Matrix.hpp"
+#include "El/core/environment/decl.hpp"
+
 namespace El {
+
+template <typename T> class DistMultiVec;
 
 template<typename T,typename S>
 void Shift( Matrix<T>& A, S alpha )

--- a/include/El/blas_like/level1/ShiftDiagonal.hpp
+++ b/include/El/blas_like/level1/ShiftDiagonal.hpp
@@ -9,7 +9,17 @@
 #ifndef EL_BLAS_SHIFTDIAGONAL_HPP
 #define EL_BLAS_SHIFTDIAGONAL_HPP
 
+#include <iosfwd>
+
+#include "El/core.hpp"
+#include "El/core/./DistMatrix/Abstract.hpp"
+#include "El/core/Matrix.hpp"
+#include "El/core/environment/decl.hpp"
+
 namespace El {
+
+template <typename T> class DistSparseMatrix;
+template <typename T> class SparseMatrix;
 
 template<typename T,typename S>
 void ShiftDiagonal( Matrix<T>& A, S alpha, Int offset )

--- a/include/El/blas_like/level1/Transpose/ColAllGather.hpp
+++ b/include/El/blas_like/level1/Transpose/ColAllGather.hpp
@@ -9,6 +9,15 @@
 #ifndef EL_BLAS_TRANSPOSE_COLALLGATHER_HPP
 #define EL_BLAS_TRANSPOSE_COLALLGATHER_HPP
 
+#include <iosfwd>
+#include <memory>
+
+#include "El/core.hpp"
+#include "El/core/./DistMatrix/Block.hpp"
+#include "El/core/./DistMatrix/Element.hpp"
+#include "El/core/environment/decl.hpp"
+#include "El/core/types.hpp"
+
 namespace El {
 namespace transpose {
 

--- a/include/El/blas_like/level1/Transpose/ColFilter.hpp
+++ b/include/El/blas_like/level1/Transpose/ColFilter.hpp
@@ -9,6 +9,15 @@
 #ifndef EL_BLAS_TRANSPOSE_COLFILTER_HPP
 #define EL_BLAS_TRANSPOSE_COLFILTER_HPP
 
+#include <iosfwd>
+#include <memory>
+
+#include "El/core.hpp"
+#include "El/core/./DistMatrix/Block.hpp"
+#include "El/core/./DistMatrix/Element.hpp"
+#include "El/core/environment/decl.hpp"
+#include "El/core/types.hpp"
+
 namespace El {
 namespace transpose {
 

--- a/include/El/blas_like/level1/Transpose/PartialColAllGather.hpp
+++ b/include/El/blas_like/level1/Transpose/PartialColAllGather.hpp
@@ -9,6 +9,15 @@
 #ifndef EL_BLAS_TRANSPOSE_PARTIALCOLALLGATHER_HPP
 #define EL_BLAS_TRANSPOSE_PARTIALCOLALLGATHER_HPP
 
+#include <iosfwd>
+#include <memory>
+
+#include "El/core.hpp"
+#include "El/core/./DistMatrix/Block.hpp"
+#include "El/core/./DistMatrix/Element.hpp"
+#include "El/core/environment/decl.hpp"
+#include "El/core/types.hpp"
+
 namespace El {
 namespace transpose {
 

--- a/include/El/blas_like/level1/Transpose/PartialRowFilter.hpp
+++ b/include/El/blas_like/level1/Transpose/PartialRowFilter.hpp
@@ -9,6 +9,15 @@
 #ifndef EL_BLAS_TRANSPOSE_PARTIALROWFILTER_HPP
 #define EL_BLAS_TRANSPOSE_PARTIALROWFILTER_HPP
 
+#include <iosfwd>
+#include <memory>
+
+#include "El/core.hpp"
+#include "El/core/./DistMatrix/Block.hpp"
+#include "El/core/./DistMatrix/Element.hpp"
+#include "El/core/environment/decl.hpp"
+#include "El/core/types.hpp"
+
 namespace El {
 namespace transpose {
 

--- a/include/El/blas_like/level1/Transpose/RowFilter.hpp
+++ b/include/El/blas_like/level1/Transpose/RowFilter.hpp
@@ -9,6 +9,15 @@
 #ifndef EL_BLAS_TRANSPOSE_ROWFILTER_HPP
 #define EL_BLAS_TRANSPOSE_ROWFILTER_HPP
 
+#include <iosfwd>
+#include <memory>
+
+#include "El/core.hpp"
+#include "El/core/./DistMatrix/Block.hpp"
+#include "El/core/./DistMatrix/Element.hpp"
+#include "El/core/environment/decl.hpp"
+#include "El/core/types.hpp"
+
 namespace El {
 namespace transpose {
 

--- a/include/El/blas_like/level1/TransposeContract.hpp
+++ b/include/El/blas_like/level1/TransposeContract.hpp
@@ -9,6 +9,15 @@
 #ifndef EL_BLAS_TRANSPOSECONTRACT_HPP
 #define EL_BLAS_TRANSPOSECONTRACT_HPP
 
+#include <iosfwd>
+#include <memory>
+
+#include "El/core.hpp"
+#include "El/core/./DistMatrix/Block.hpp"
+#include "El/core/./DistMatrix/Element.hpp"
+#include "El/core/environment/decl.hpp"
+#include "El/core/types.hpp"
+
 namespace El {
 
 template<typename T>

--- a/include/El/blas_like/level1/UpdateDiagonal.hpp
+++ b/include/El/blas_like/level1/UpdateDiagonal.hpp
@@ -9,7 +9,24 @@
 #ifndef EL_BLAS_UPDATEDIAGONAL_HPP
 #define EL_BLAS_UPDATEDIAGONAL_HPP
 
+#include <functional>
+#include <iosfwd>
+
+#include "El/core.hpp"
+#include "El/core/./DistMatrix/Element.hpp"
+#include "El/core/Element/decl.hpp"
+#include "El/core/Element/impl.hpp"
+#include "El/core/Matrix.hpp"
+#include "El/core/environment/decl.hpp"
+#include "El/core/imports/mpi.hpp"
+#include "El/core/types.hpp"
+
 namespace El {
+
+template <typename T = double, El::DistNS::Dist U = MC, El::DistNS::Dist V = MR, El::DistWrapNS::DistWrap wrap = ELEMENT> class DistMatrix;
+template <typename T> class DistMultiVec;
+template <typename T> class DistSparseMatrix;
+template <typename T> class SparseMatrix;
 
 template<typename T>
 void UpdateDiagonal( Matrix<T>& A, T alpha, const Matrix<T>& d, Int offset )

--- a/include/El/blas_like/level1/UpdateDiagonal.hpp
+++ b/include/El/blas_like/level1/UpdateDiagonal.hpp
@@ -23,7 +23,6 @@
 
 namespace El {
 
-template <typename T = double, El::DistNS::Dist U = MC, El::DistNS::Dist V = MR, El::DistWrapNS::DistWrap wrap = ELEMENT> class DistMatrix;
 template <typename T> class DistMultiVec;
 template <typename T> class DistSparseMatrix;
 template <typename T> class SparseMatrix;

--- a/include/El/blas_like/level1/UpdateMappedDiagonal.hpp
+++ b/include/El/blas_like/level1/UpdateMappedDiagonal.hpp
@@ -9,7 +9,24 @@
 #ifndef EL_BLAS_UPDATEMAPPEDDIAGONAL_HPP
 #define EL_BLAS_UPDATEMAPPEDDIAGONAL_HPP
 
+#include <functional>
+#include <iosfwd>
+
+#include "El/core.hpp"
+#include "El/core/./DistMatrix/Element.hpp"
+#include "El/core/Matrix.hpp"
+#include "El/core/Proxy.hpp"
+#include "El/core/environment/decl.hpp"
+#include "El/core/imports/mpi.hpp"
+#include "El/core/imports/omp.hpp"
+#include "El/core/types.hpp"
+
 namespace El {
+
+template <typename T = double, El::DistNS::Dist U = MC, El::DistNS::Dist V = MR, El::DistWrapNS::DistWrap wrap = ELEMENT> class DistMatrix;
+template <typename T> class DistMultiVec;
+template <typename T> class DistSparseMatrix;
+template <typename T> class SparseMatrix;
 
 template<typename T,typename S>
 void UpdateMappedDiagonal

--- a/include/El/blas_like/level1/UpdateMappedDiagonal.hpp
+++ b/include/El/blas_like/level1/UpdateMappedDiagonal.hpp
@@ -23,7 +23,6 @@
 
 namespace El {
 
-template <typename T = double, El::DistNS::Dist U = MC, El::DistNS::Dist V = MR, El::DistWrapNS::DistWrap wrap = ELEMENT> class DistMatrix;
 template <typename T> class DistMultiVec;
 template <typename T> class DistSparseMatrix;
 template <typename T> class SparseMatrix;

--- a/include/El/blas_like/level1/UpdateSubmatrix.hpp
+++ b/include/El/blas_like/level1/UpdateSubmatrix.hpp
@@ -9,6 +9,14 @@
 #ifndef EL_BLAS_UPDATESUBMATRIX_HPP
 #define EL_BLAS_UPDATESUBMATRIX_HPP
 
+#include <iosfwd>
+#include <vector>
+
+#include "El/core.hpp"
+#include "El/core/./DistMatrix/Abstract.hpp"
+#include "El/core/Matrix.hpp"
+#include "El/core/environment/decl.hpp"
+
 namespace El {
 
 template<typename T>

--- a/include/El/blas_like/level3.hpp
+++ b/include/El/blas_like/level3.hpp
@@ -16,7 +16,6 @@
 #include "El/core/types.hpp"
 
 namespace El {
-template <typename T = double, El::DistNS::Dist U = MC, El::DistNS::Dist V = MR, El::DistWrapNS::DistWrap wrap = ELEMENT> class DistMatrix;
 template <typename T> class DistMultiVec;
 template <typename T> class DistSparseMatrix;
 template <typename T> class SparseMatrix;

--- a/include/El/blas_like/level3.hpp
+++ b/include/El/blas_like/level3.hpp
@@ -9,6 +9,19 @@
 #ifndef EL_BLAS3_HPP
 #define EL_BLAS3_HPP
 
+#include "El/core/./DistMatrix/Abstract.hpp"
+#include "El/core/./DistMatrix/Element.hpp"
+#include "El/core/Element/decl.hpp"
+#include "El/core/Matrix.hpp"
+#include "El/core/types.hpp"
+
+namespace El {
+template <typename T = double, El::DistNS::Dist U = MC, El::DistNS::Dist V = MR, El::DistWrapNS::DistWrap wrap = ELEMENT> class DistMatrix;
+template <typename T> class DistMultiVec;
+template <typename T> class DistSparseMatrix;
+template <typename T> class SparseMatrix;
+}  // namespace El
+
 namespace El {
 
 // Gemm

--- a/include/El/core.hpp
+++ b/include/El/core.hpp
@@ -12,7 +12,6 @@
 // This would ideally be included within core/imports/mpi.hpp, but it is 
 // well-known that this must often be included first.
 #include <mpi.h>
-
 #include <array>
 #include <cmath>
 #include <complex>
@@ -24,10 +23,10 @@
 #include <functional>
 #include <iostream>
 #include <memory>
+#include <random>
 #include <sstream>
 #include <stdexcept>
 #include <string>
-#include <random>
 #include <type_traits> // std::enable_if
 #include <vector>
 
@@ -84,71 +83,62 @@ typedef __float128 Quad;
 
 } // namespace El
 
-// Declare the intertwined core parts of our library
-#include "El/core/imports/valgrind.hpp"
-#include "El/core/imports/omp.hpp"
-#include "El/core/imports/qd.hpp"
-#include "El/core/imports/mpc.hpp"
-#include "El/core/Memory.hpp"
 #include "El/core/Element/decl.hpp"
-#include "El/core/types.hpp"
+#include "El/core/Memory.hpp"
 #include "El/core/Serialize.hpp"
-#include "El/core/imports/mpi.hpp"
-#include "El/core/imports/choice.hpp"
-#include "El/core/imports/mpi_choice.hpp"
-#include "El/core/environment/decl.hpp"
-
 #include "El/core/Timer.hpp"
-#include "El/core/indexing/decl.hpp"
+#include "El/core/environment/decl.hpp"
 #include "El/core/imports/blas.hpp"
-#include "El/core/imports/lapack.hpp"
+#include "El/core/imports/choice.hpp"
 #include "El/core/imports/flame.hpp"
+#include "El/core/imports/lapack.hpp"
 #include "El/core/imports/mkl.hpp"
+#include "El/core/imports/mpc.hpp"
+#include "El/core/imports/mpi.hpp"
+#include "El/core/imports/mpi_choice.hpp"
+#include "El/core/imports/omp.hpp"
 #include "El/core/imports/openblas.hpp"
 #include "El/core/imports/pmrrr.hpp"
+#include "El/core/imports/qd.hpp"
 #include "El/core/imports/scalapack.hpp"
-
+// Declare the intertwined core parts of our library
+#include "El/core/imports/valgrind.hpp"
+#include "El/core/indexing/decl.hpp"
 #include "El/core/limits.hpp"
+#include "El/core/types.hpp"
 
 namespace El {
 
-template<typename T=double> class Matrix;
-
-template<typename T=double> class AbstractDistMatrix;
-
-template<typename T=double> class ElementalMatrix;
-template<typename T=double> class BlockMatrix;
-
 template<typename T=double,Dist U=MC,Dist V=MR,DistWrap wrap=ELEMENT>
 class DistMatrix;
+template<typename T=double> class AbstractDistMatrix;
+template<typename T=double> class BlockMatrix;
+template<typename T=double> class ElementalMatrix;
+template<typename T=double> class Matrix;
 
 } // namespace El
 
-#include "El/core/Matrix.hpp"
-#include "El/core/Grid.hpp"
+#include "El/core/DistGraph.hpp"
+#include "El/core/DistMap.hpp"
 #include "El/core/DistMatrix.hpp"
-#include "El/core/Proxy.hpp"
-
+#include "El/core/DistMultiVec.hpp"
+#include "El/core/DistSparseMatrix.hpp"
 // Implement the intertwined parts of the library
 #include "El/core/Element/impl.hpp"
-#include "El/core/environment/impl.hpp"
-#include "El/core/indexing/impl.hpp"
-
-// Declare and implement the decoupled parts of the core of the library
-// (perhaps these should be moved into their own directory?)
-#include "El/core/View.hpp"
 #include "El/core/FlamePart.hpp"
-#include "El/core/random/decl.hpp"
-#include "El/core/random/impl.hpp"
-
 #include "El/core/Graph.hpp"
+#include "El/core/Grid.hpp"
+#include "El/core/Matrix.hpp"
+#include "El/core/Proxy.hpp"
 // TODO: Sequential map
 //#include "El/core/Map.hpp"
 #include "El/core/SparseMatrix.hpp"
-
-#include "El/core/DistGraph.hpp"
-#include "El/core/DistMap.hpp"
-#include "El/core/DistMultiVec.hpp"
-#include "El/core/DistSparseMatrix.hpp"
+// Declare and implement the decoupled parts of the core of the library
+// (perhaps these should be moved into their own directory?)
+#include "El/core/View.hpp"
+#include "El/core/environment/impl.hpp"
+#include "El/core/indexing/impl.hpp"
+#include "El/core/random/decl.hpp"
+#include "El/core/random/impl.hpp"
 
 #endif // ifndef EL_CORE_HPP

--- a/include/El/core/DistGraph.hpp
+++ b/include/El/core/DistGraph.hpp
@@ -12,13 +12,21 @@
 #define EL_CORE_DISTGRAPH_DECL_HPP
 
 #include <set>
+#include <utility>
+#include <vector>
+
+#include "El/core/Graph.hpp"
+#include "El/core/imports/mpi.hpp"
+#include "El/core/types.hpp"
 
 namespace El {
 
 using std::set;
 
 // Forward declare ldl::DistFront
-namespace ldl { template<typename F> struct DistFront; }
+namespace ldl {
+template<typename F> struct DistFront;
+}  // namespace ldl
 
 // Use a simple 1d distribution where each process owns a fixed number of 
 // sources:

--- a/include/El/core/DistMap.hpp
+++ b/include/El/core/DistMap.hpp
@@ -11,6 +11,10 @@
 #ifndef EL_CORE_DISTMAP_DECL_HPP
 #define EL_CORE_DISTMAP_DECL_HPP
 
+#include <vector>
+
+#include "El/core/imports/mpi.hpp"
+
 namespace El {
 
 // Use a simple 1d distribution where each process owns a fixed number of 

--- a/include/El/core/DistMatrix.hpp
+++ b/include/El/core/DistMatrix.hpp
@@ -9,6 +9,10 @@
 #ifndef EL_CORE_DISTMATRIX_HPP
 #define EL_CORE_DISTMATRIX_HPP
 
+#include <ostream>
+
+#include "El/core/environment/decl.hpp"
+
 namespace El {
 
 template<typename DistTypeA,typename DistTypeB>
@@ -24,23 +28,6 @@ class DistMultiVec;
 } // namespace El
 
 #include "./DistMatrix/Abstract.hpp"
-
-#include "./DistMatrix/Element.hpp"
-#include "./DistMatrix/Element/CIRC_CIRC.hpp"
-#include "./DistMatrix/Element/MC_MR.hpp"
-#include "./DistMatrix/Element/MC_STAR.hpp"
-#include "./DistMatrix/Element/MD_STAR.hpp"
-#include "./DistMatrix/Element/MR_MC.hpp"
-#include "./DistMatrix/Element/MR_STAR.hpp"
-#include "./DistMatrix/Element/STAR_MC.hpp"
-#include "./DistMatrix/Element/STAR_MD.hpp"
-#include "./DistMatrix/Element/STAR_MR.hpp"
-#include "./DistMatrix/Element/STAR_STAR.hpp"
-#include "./DistMatrix/Element/STAR_VC.hpp"
-#include "./DistMatrix/Element/STAR_VR.hpp"
-#include "./DistMatrix/Element/VC_STAR.hpp"
-#include "./DistMatrix/Element/VR_STAR.hpp"
-
 #include "./DistMatrix/Block.hpp"
 #include "./DistMatrix/Block/CIRC_CIRC.hpp"
 #include "./DistMatrix/Block/MC_MR.hpp"
@@ -56,6 +43,21 @@ class DistMultiVec;
 #include "./DistMatrix/Block/STAR_VR.hpp"
 #include "./DistMatrix/Block/VC_STAR.hpp"
 #include "./DistMatrix/Block/VR_STAR.hpp"
+#include "./DistMatrix/Element.hpp"
+#include "./DistMatrix/Element/CIRC_CIRC.hpp"
+#include "./DistMatrix/Element/MC_MR.hpp"
+#include "./DistMatrix/Element/MC_STAR.hpp"
+#include "./DistMatrix/Element/MD_STAR.hpp"
+#include "./DistMatrix/Element/MR_MC.hpp"
+#include "./DistMatrix/Element/MR_STAR.hpp"
+#include "./DistMatrix/Element/STAR_MC.hpp"
+#include "./DistMatrix/Element/STAR_MD.hpp"
+#include "./DistMatrix/Element/STAR_MR.hpp"
+#include "./DistMatrix/Element/STAR_STAR.hpp"
+#include "./DistMatrix/Element/STAR_VC.hpp"
+#include "./DistMatrix/Element/STAR_VR.hpp"
+#include "./DistMatrix/Element/VC_STAR.hpp"
+#include "./DistMatrix/Element/VR_STAR.hpp"
 
 namespace El {
 

--- a/include/El/core/DistMatrix/Abstract.hpp
+++ b/include/El/core/DistMatrix/Abstract.hpp
@@ -9,6 +9,16 @@
 #ifndef EL_DISTMATRIX_ABSTRACT_HPP
 #define EL_DISTMATRIX_ABSTRACT_HPP
 
+#include <stddef.h>
+#include <vector>
+
+#include "El/core/Element/decl.hpp"
+#include "El/core/Grid.hpp"
+#include "El/core/Matrix.hpp"
+#include "El/core/environment/decl.hpp"
+#include "El/core/imports/mpi.hpp"
+#include "El/core/types.hpp"
+
 namespace El {
 
 struct DistData;

--- a/include/El/core/DistMatrix/Block.hpp
+++ b/include/El/core/DistMatrix/Block.hpp
@@ -9,6 +9,11 @@
 #ifndef EL_DISTMATRIX_BLOCK_HPP
 #define EL_DISTMATRIX_BLOCK_HPP
 
+#include "El/core/./DistMatrix/Abstract.hpp"
+#include "El/core/Grid.hpp"
+#include "El/core/Matrix.hpp"
+#include "El/core/types.hpp"
+
 namespace El {
 
 template<typename T> 

--- a/include/El/core/DistMatrix/Block/CIRC_CIRC.hpp
+++ b/include/El/core/DistMatrix/Block/CIRC_CIRC.hpp
@@ -146,7 +146,6 @@ public:
     int PartialUnionRowRank() const EL_NO_EXCEPT override;
 
 private:
-    template<typename S,Dist U,Dist V,DistWrap wrap> friend class DistMatrix;
 };
 
 } // namespace El

--- a/include/El/core/DistMatrix/Block/MC_MR.hpp
+++ b/include/El/core/DistMatrix/Block/MC_MR.hpp
@@ -162,7 +162,6 @@ public:
     int PartialUnionRowRank() const EL_NO_EXCEPT override;
 
 private:
-    template<typename S,Dist U,Dist V,DistWrap wrap> friend class DistMatrix;
 };
 
 } // namespace El

--- a/include/El/core/DistMatrix/Block/MC_STAR.hpp
+++ b/include/El/core/DistMatrix/Block/MC_STAR.hpp
@@ -160,7 +160,6 @@ public:
     int PartialUnionRowRank() const EL_NO_EXCEPT override;
 
 private:
-    template<typename S,Dist U,Dist V,DistWrap wrap> friend class DistMatrix;
 };
 
 } // namespace El

--- a/include/El/core/DistMatrix/Block/MD_STAR.hpp
+++ b/include/El/core/DistMatrix/Block/MD_STAR.hpp
@@ -161,7 +161,6 @@ public:
     int PartialUnionRowRank() const EL_NO_EXCEPT override;
 
 private:
-    template<typename S,Dist U,Dist V,DistWrap wrap> friend class DistMatrix;
 };
 
 } // namespace El

--- a/include/El/core/DistMatrix/Block/MR_MC.hpp
+++ b/include/El/core/DistMatrix/Block/MR_MC.hpp
@@ -161,7 +161,6 @@ public:
     int PartialUnionRowRank() const EL_NO_EXCEPT override;
 
 private:
-    template<typename S,Dist U,Dist V,DistWrap wrap> friend class DistMatrix;
 };
 
 } // namespace El

--- a/include/El/core/DistMatrix/Block/MR_STAR.hpp
+++ b/include/El/core/DistMatrix/Block/MR_STAR.hpp
@@ -160,7 +160,6 @@ public:
     int PartialUnionRowRank() const EL_NO_EXCEPT override;
 
 private:
-    template<typename S,Dist U,Dist V,DistWrap wrap> friend class DistMatrix;
 };
 
 } // namespace El

--- a/include/El/core/DistMatrix/Block/STAR_MC.hpp
+++ b/include/El/core/DistMatrix/Block/STAR_MC.hpp
@@ -160,7 +160,6 @@ public:
     int PartialUnionRowRank() const EL_NO_EXCEPT override;
 
 private:
-    template<typename S,Dist U,Dist V,DistWrap wrap> friend class DistMatrix;
 };
 
 } // namespace El

--- a/include/El/core/DistMatrix/Block/STAR_MD.hpp
+++ b/include/El/core/DistMatrix/Block/STAR_MD.hpp
@@ -161,7 +161,6 @@ public:
     int PartialUnionRowRank() const EL_NO_EXCEPT override;
 
 private:
-    template<typename S,Dist U,Dist V,DistWrap wrap> friend class DistMatrix;
 };
 
 } // namespace El

--- a/include/El/core/DistMatrix/Block/STAR_MR.hpp
+++ b/include/El/core/DistMatrix/Block/STAR_MR.hpp
@@ -159,7 +159,6 @@ public:
     int PartialUnionRowRank() const EL_NO_EXCEPT override;
 
 private:
-    template<typename S,Dist U,Dist V,DistWrap wrap> friend class DistMatrix;
 };
 
 } // namespace El

--- a/include/El/core/DistMatrix/Block/STAR_STAR.hpp
+++ b/include/El/core/DistMatrix/Block/STAR_STAR.hpp
@@ -159,7 +159,6 @@ public:
     int PartialUnionRowRank() const EL_NO_EXCEPT override;
 
 private:
-    template<typename S,Dist U,Dist V,DistWrap wrap> friend class DistMatrix;
 };
 
 } // namespace El

--- a/include/El/core/DistMatrix/Block/STAR_VC.hpp
+++ b/include/El/core/DistMatrix/Block/STAR_VC.hpp
@@ -159,7 +159,6 @@ public:
     int PartialUnionRowRank() const EL_NO_EXCEPT override;
 
 private:
-    template<typename S,Dist U,Dist V,DistWrap wrap> friend class DistMatrix;
 };
 
 } // namespace El

--- a/include/El/core/DistMatrix/Block/STAR_VR.hpp
+++ b/include/El/core/DistMatrix/Block/STAR_VR.hpp
@@ -159,7 +159,6 @@ public:
     int PartialUnionRowRank() const EL_NO_EXCEPT override;
 
 private:
-    template<typename S,Dist U,Dist V,DistWrap wrap> friend class DistMatrix;
 };
 
 } // namespace El

--- a/include/El/core/DistMatrix/Block/VC_STAR.hpp
+++ b/include/El/core/DistMatrix/Block/VC_STAR.hpp
@@ -159,7 +159,6 @@ public:
     int PartialUnionRowRank() const EL_NO_EXCEPT override;
 
 private:
-    template<typename S,Dist U,Dist V,DistWrap wrap> friend class DistMatrix;
 };
 
 } // namespace El

--- a/include/El/core/DistMatrix/Block/VR_STAR.hpp
+++ b/include/El/core/DistMatrix/Block/VR_STAR.hpp
@@ -159,7 +159,6 @@ public:
     int PartialUnionRowRank() const EL_NO_EXCEPT override;
 
 private:
-    template<typename S,Dist U,Dist V,DistWrap wrap> friend class DistMatrix;
 };
 
 } // namespace El

--- a/include/El/core/DistMatrix/Element/CIRC_CIRC.hpp
+++ b/include/El/core/DistMatrix/Element/CIRC_CIRC.hpp
@@ -22,7 +22,6 @@ namespace El {
 // Partial specialization to A[o,o].
 //
 // The entire matrix is only stored on a single process.
-//template <typename T = double, El::DistNS::Dist U = MC, El::DistNS::Dist V = MR, El::DistWrapNS::DistWrap wrap = ELEMENT> class DistMatrix;
 
 template<typename T>
 class DistMatrix<T,CIRC,CIRC> : public ElementalMatrix<T>
@@ -147,7 +146,6 @@ public:
     int PartialUnionRowRank() const EL_NO_EXCEPT override;
 
 private:
-    template<typename S,Dist U,Dist V,DistWrap wrap> friend class DistMatrix;
 };
 
 } // namespace El

--- a/include/El/core/DistMatrix/Element/CIRC_CIRC.hpp
+++ b/include/El/core/DistMatrix/Element/CIRC_CIRC.hpp
@@ -9,11 +9,21 @@
 #ifndef EL_DISTMATRIX_ELEMENTAL_CIRC_CIRC_HPP
 #define EL_DISTMATRIX_ELEMENTAL_CIRC_CIRC_HPP
 
+#include <vector>
+
+#include "El/core/./DistMatrix/Abstract.hpp"
+#include "El/core/./DistMatrix/Element.hpp"
+#include "El/core/Grid.hpp"
+#include "El/core/imports/mpi.hpp"
+#include "El/core/types.hpp"
+
 namespace El {
 
 // Partial specialization to A[o,o].
 //
 // The entire matrix is only stored on a single process.
+//template <typename T = double, El::DistNS::Dist U = MC, El::DistNS::Dist V = MR, El::DistWrapNS::DistWrap wrap = ELEMENT> class DistMatrix;
+
 template<typename T>
 class DistMatrix<T,CIRC,CIRC> : public ElementalMatrix<T>
 {

--- a/include/El/core/DistMatrix/Element/MC_MR.hpp
+++ b/include/El/core/DistMatrix/Element/MC_MR.hpp
@@ -25,7 +25,6 @@ namespace El {
 // process grid, and the rows will be distributed among rows of the process
 // grid.
 
-//template <typename T = double, El::DistNS::Dist U = MC, El::DistNS::Dist V = MR, El::DistWrapNS::DistWrap wrap = ELEMENT> class DistMatrix;
 
 template<typename T>
 class DistMatrix<T,MC,MR> : public ElementalMatrix<T>
@@ -163,7 +162,6 @@ public:
     int PartialUnionRowRank() const EL_NO_EXCEPT override;
 
 private:
-    template<typename S,Dist U,Dist V,DistWrap wrap> friend class DistMatrix;
 };
 
 } // namespace El

--- a/include/El/core/DistMatrix/Element/MC_MR.hpp
+++ b/include/El/core/DistMatrix/Element/MC_MR.hpp
@@ -9,6 +9,14 @@
 #ifndef EL_DISTMATRIX_ELEMENTAL_MC_MR_HPP
 #define EL_DISTMATRIX_ELEMENTAL_MC_MR_HPP
 
+#include <vector>
+
+#include "El/core/./DistMatrix/Abstract.hpp"
+#include "El/core/./DistMatrix/Element.hpp"
+#include "El/core/Grid.hpp"
+#include "El/core/imports/mpi.hpp"
+#include "El/core/types.hpp"
+
 namespace El {
 
 // Partial specialization to A[MC,MR].
@@ -16,6 +24,8 @@ namespace El {
 // The columns of these matrices will be distributed among columns of the
 // process grid, and the rows will be distributed among rows of the process
 // grid.
+
+//template <typename T = double, El::DistNS::Dist U = MC, El::DistNS::Dist V = MR, El::DistWrapNS::DistWrap wrap = ELEMENT> class DistMatrix;
 
 template<typename T>
 class DistMatrix<T,MC,MR> : public ElementalMatrix<T>

--- a/include/El/core/DistMatrix/Element/MC_STAR.hpp
+++ b/include/El/core/DistMatrix/Element/MC_STAR.hpp
@@ -9,6 +9,14 @@
 #ifndef EL_DISTMATRIX_ELEMENTAL_MC_STAR_HPP
 #define EL_DISTMATRIX_ELEMENTAL_MC_STAR_HPP
 
+#include <vector>
+
+#include "El/core/./DistMatrix/Abstract.hpp"
+#include "El/core/./DistMatrix/Element.hpp"
+#include "El/core/Grid.hpp"
+#include "El/core/imports/mpi.hpp"
+#include "El/core/types.hpp"
+
 namespace El {
 
 // Partial specialization to A[MC,* ].
@@ -17,6 +25,8 @@ namespace El {
 // processes (*), and the columns will be distributed like "Matrix Columns" 
 // (MC). Thus the columns will be distributed among columns of the process
 // grid.
+//template <typename T = double, El::DistNS::Dist U = MC, El::DistNS::Dist V = MR, El::DistWrapNS::DistWrap wrap = ELEMENT> class DistMatrix;
+
 template<typename T>
 class DistMatrix<T,MC,STAR> : public ElementalMatrix<T>
 {

--- a/include/El/core/DistMatrix/Element/MC_STAR.hpp
+++ b/include/El/core/DistMatrix/Element/MC_STAR.hpp
@@ -25,7 +25,6 @@ namespace El {
 // processes (*), and the columns will be distributed like "Matrix Columns" 
 // (MC). Thus the columns will be distributed among columns of the process
 // grid.
-//template <typename T = double, El::DistNS::Dist U = MC, El::DistNS::Dist V = MR, El::DistWrapNS::DistWrap wrap = ELEMENT> class DistMatrix;
 
 template<typename T>
 class DistMatrix<T,MC,STAR> : public ElementalMatrix<T>
@@ -163,7 +162,6 @@ public:
     int PartialUnionRowRank() const EL_NO_EXCEPT override;
 
 private:
-    template<typename S,Dist U,Dist V,DistWrap wrap> friend class DistMatrix;
 };
 
 } // namespace El

--- a/include/El/core/DistMatrix/Element/MD_STAR.hpp
+++ b/include/El/core/DistMatrix/Element/MD_STAR.hpp
@@ -9,6 +9,14 @@
 #ifndef EL_DISTMATRIX_ELEMENTAL_MD_STAR_HPP
 #define EL_DISTMATRIX_ELEMENTAL_MD_STAR_HPP
 
+#include <vector>
+
+#include "El/core/./DistMatrix/Abstract.hpp"
+#include "El/core/./DistMatrix/Element.hpp"
+#include "El/core/Grid.hpp"
+#include "El/core/imports/mpi.hpp"
+#include "El/core/types.hpp"
+
 namespace El {
 
 // Partial specialization to A[MD,* ].
@@ -18,6 +26,8 @@ namespace El {
 // of a sufficiently large distributed matrix is distributed amongst the 
 // entire process grid if and only if the dimensions of the process grid
 // are coprime.
+//template <typename T = double, El::DistNS::Dist U = MC, El::DistNS::Dist V = MR, El::DistWrapNS::DistWrap wrap = ELEMENT> class DistMatrix;
+
 template<typename T>
 class DistMatrix<T,MD,STAR> : public ElementalMatrix<T>
 {

--- a/include/El/core/DistMatrix/Element/MD_STAR.hpp
+++ b/include/El/core/DistMatrix/Element/MD_STAR.hpp
@@ -26,7 +26,6 @@ namespace El {
 // of a sufficiently large distributed matrix is distributed amongst the 
 // entire process grid if and only if the dimensions of the process grid
 // are coprime.
-//template <typename T = double, El::DistNS::Dist U = MC, El::DistNS::Dist V = MR, El::DistWrapNS::DistWrap wrap = ELEMENT> class DistMatrix;
 
 template<typename T>
 class DistMatrix<T,MD,STAR> : public ElementalMatrix<T>
@@ -164,7 +163,6 @@ public:
     int PartialUnionRowRank() const EL_NO_EXCEPT override;
 
 private:
-    template<typename S,Dist U,Dist V,DistWrap wrap> friend class DistMatrix;
 };
 
 } // namespace El

--- a/include/El/core/DistMatrix/Element/MR_MC.hpp
+++ b/include/El/core/DistMatrix/Element/MR_MC.hpp
@@ -9,6 +9,14 @@
 #ifndef EL_DISTMATRIX_ELEMENTAL_MR_MC_HPP
 #define EL_DISTMATRIX_ELEMENTAL_MR_MC_HPP
 
+#include <vector>
+
+#include "El/core/./DistMatrix/Abstract.hpp"
+#include "El/core/./DistMatrix/Element.hpp"
+#include "El/core/Grid.hpp"
+#include "El/core/imports/mpi.hpp"
+#include "El/core/types.hpp"
+
 namespace El {
 
 // Partial specialization to A[MR,MC].
@@ -18,6 +26,8 @@ namespace El {
 // "Matrix Columns" (MC). Thus the columns will be distributed within 
 // rows of the process grid and the rows will be distributed within columns
 // of the process grid.
+//template <typename T = double, El::DistNS::Dist U = MC, El::DistNS::Dist V = MR, El::DistWrapNS::DistWrap wrap = ELEMENT> class DistMatrix;
+
 template<typename T>
 class DistMatrix<T,MR,MC> : public ElementalMatrix<T>
 {

--- a/include/El/core/DistMatrix/Element/MR_MC.hpp
+++ b/include/El/core/DistMatrix/Element/MR_MC.hpp
@@ -26,7 +26,6 @@ namespace El {
 // "Matrix Columns" (MC). Thus the columns will be distributed within 
 // rows of the process grid and the rows will be distributed within columns
 // of the process grid.
-//template <typename T = double, El::DistNS::Dist U = MC, El::DistNS::Dist V = MR, El::DistWrapNS::DistWrap wrap = ELEMENT> class DistMatrix;
 
 template<typename T>
 class DistMatrix<T,MR,MC> : public ElementalMatrix<T>
@@ -164,7 +163,6 @@ public:
     int PartialUnionRowRank() const EL_NO_EXCEPT override;
 
 private:
-    template<typename S,Dist U,Dist V,DistWrap wrap> friend class DistMatrix;
 };
 
 } // namespace El

--- a/include/El/core/DistMatrix/Element/MR_STAR.hpp
+++ b/include/El/core/DistMatrix/Element/MR_STAR.hpp
@@ -25,7 +25,6 @@ namespace El {
 // processes (*), and the columns will be distributed like "Matrix Rows" 
 // (MR). Thus the columns will be distributed among rows of the process
 // grid.
-//template <typename T = double, El::DistNS::Dist U = MC, El::DistNS::Dist V = MR, El::DistWrapNS::DistWrap wrap = ELEMENT> class DistMatrix;
 
 template<typename T>
 class DistMatrix<T,MR,STAR> : public ElementalMatrix<T>
@@ -163,7 +162,6 @@ public:
     int PartialUnionRowRank() const EL_NO_EXCEPT override;
 
 private:
-    template<typename S,Dist U,Dist V,DistWrap wrap> friend class DistMatrix;
 };
 
 } // namespace El

--- a/include/El/core/DistMatrix/Element/MR_STAR.hpp
+++ b/include/El/core/DistMatrix/Element/MR_STAR.hpp
@@ -9,6 +9,14 @@
 #ifndef EL_DISTMATRIX_ELEMENTAL_MR_STAR_HPP
 #define EL_DISTMATRIX_ELEMENTAL_MR_STAR_HPP
 
+#include <vector>
+
+#include "El/core/./DistMatrix/Abstract.hpp"
+#include "El/core/./DistMatrix/Element.hpp"
+#include "El/core/Grid.hpp"
+#include "El/core/imports/mpi.hpp"
+#include "El/core/types.hpp"
+
 namespace El {
 
 // Partial specialization to A[MR,* ].
@@ -17,6 +25,8 @@ namespace El {
 // processes (*), and the columns will be distributed like "Matrix Rows" 
 // (MR). Thus the columns will be distributed among rows of the process
 // grid.
+//template <typename T = double, El::DistNS::Dist U = MC, El::DistNS::Dist V = MR, El::DistWrapNS::DistWrap wrap = ELEMENT> class DistMatrix;
+
 template<typename T>
 class DistMatrix<T,MR,STAR> : public ElementalMatrix<T>
 {

--- a/include/El/core/DistMatrix/Element/STAR_MC.hpp
+++ b/include/El/core/DistMatrix/Element/STAR_MC.hpp
@@ -9,6 +9,14 @@
 #ifndef EL_DISTMATRIX_ELEMENTAL_STAR_MC_HPP
 #define EL_DISTMATRIX_ELEMENTAL_STAR_MC_HPP
 
+#include <vector>
+
+#include "El/core/./DistMatrix/Abstract.hpp"
+#include "El/core/./DistMatrix/Element.hpp"
+#include "El/core/Grid.hpp"
+#include "El/core/imports/mpi.hpp"
+#include "El/core/types.hpp"
+
 namespace El {
 
 // Partial specialization to A[* ,MC].
@@ -17,6 +25,8 @@ namespace El {
 // processes (*), and the rows will be distributed like "Matrix Columns" 
 // (MC). Thus the rows will be distributed among columns of the process
 // grid.
+//template <typename T = double, El::DistNS::Dist U = MC, El::DistNS::Dist V = MR, El::DistWrapNS::DistWrap wrap = ELEMENT> class DistMatrix;
+
 template<typename T>
 class DistMatrix<T,STAR,MC> : public ElementalMatrix<T>
 {

--- a/include/El/core/DistMatrix/Element/STAR_MC.hpp
+++ b/include/El/core/DistMatrix/Element/STAR_MC.hpp
@@ -25,7 +25,6 @@ namespace El {
 // processes (*), and the rows will be distributed like "Matrix Columns" 
 // (MC). Thus the rows will be distributed among columns of the process
 // grid.
-//template <typename T = double, El::DistNS::Dist U = MC, El::DistNS::Dist V = MR, El::DistWrapNS::DistWrap wrap = ELEMENT> class DistMatrix;
 
 template<typename T>
 class DistMatrix<T,STAR,MC> : public ElementalMatrix<T>
@@ -163,7 +162,6 @@ public:
     int PartialUnionRowRank() const EL_NO_EXCEPT override;
 
 private:
-    template<typename S,Dist U,Dist V,DistWrap wrap> friend class DistMatrix;
 };
 
 } // namespace El

--- a/include/El/core/DistMatrix/Element/STAR_MD.hpp
+++ b/include/El/core/DistMatrix/Element/STAR_MD.hpp
@@ -26,7 +26,6 @@ namespace El {
 // of a sufficiently large distributed matrix is distributed amongst the 
 // entire process grid if and only if the dimensions of the process grid
 // are coprime.
-//template <typename T = double, El::DistNS::Dist U = MC, El::DistNS::Dist V = MR, El::DistWrapNS::DistWrap wrap = ELEMENT> class DistMatrix;
 
 template<typename T>
 class DistMatrix<T,STAR,MD> : public ElementalMatrix<T>
@@ -164,7 +163,6 @@ public:
     int PartialUnionRowRank() const EL_NO_EXCEPT override;
 
 private:
-    template<typename S,Dist U,Dist V,DistWrap wrap> friend class DistMatrix;
 };
 
 } // namespace El

--- a/include/El/core/DistMatrix/Element/STAR_MD.hpp
+++ b/include/El/core/DistMatrix/Element/STAR_MD.hpp
@@ -9,6 +9,14 @@
 #ifndef EL_DISTMATRIX_ELEMENTAL_STAR_MD_HPP
 #define EL_DISTMATRIX_ELEMENTAL_STAR_MD_HPP
 
+#include <vector>
+
+#include "El/core/./DistMatrix/Abstract.hpp"
+#include "El/core/./DistMatrix/Element.hpp"
+#include "El/core/Grid.hpp"
+#include "El/core/imports/mpi.hpp"
+#include "El/core/types.hpp"
+
 namespace El {
 
 // Partial specialization to A[* ,MD].
@@ -18,6 +26,8 @@ namespace El {
 // of a sufficiently large distributed matrix is distributed amongst the 
 // entire process grid if and only if the dimensions of the process grid
 // are coprime.
+//template <typename T = double, El::DistNS::Dist U = MC, El::DistNS::Dist V = MR, El::DistWrapNS::DistWrap wrap = ELEMENT> class DistMatrix;
+
 template<typename T>
 class DistMatrix<T,STAR,MD> : public ElementalMatrix<T>
 {

--- a/include/El/core/DistMatrix/Element/STAR_MR.hpp
+++ b/include/El/core/DistMatrix/Element/STAR_MR.hpp
@@ -9,6 +9,14 @@
 #ifndef EL_DISTMATRIX_ELEMENTAL_STAR_MR_HPP
 #define EL_DISTMATRIX_ELEMENTAL_STAR_MR_HPP
 
+#include <vector>
+
+#include "El/core/./DistMatrix/Abstract.hpp"
+#include "El/core/./DistMatrix/Element.hpp"
+#include "El/core/Grid.hpp"
+#include "El/core/imports/mpi.hpp"
+#include "El/core/types.hpp"
+
 namespace El {
 
 // Partial specialization to A[* ,MR].
@@ -16,6 +24,8 @@ namespace El {
 // The columns of these distributed matrices will be replicated on all 
 // processes (*), and the rows will be distributed like "Matrix Rows" (MR).
 // Thus the rows will be distributed among rows of the process grid.
+//template <typename T = double, El::DistNS::Dist U = MC, El::DistNS::Dist V = MR, El::DistWrapNS::DistWrap wrap = ELEMENT> class DistMatrix;
+
 template<typename T>
 class DistMatrix<T,STAR,MR> : public ElementalMatrix<T>
 {

--- a/include/El/core/DistMatrix/Element/STAR_MR.hpp
+++ b/include/El/core/DistMatrix/Element/STAR_MR.hpp
@@ -24,7 +24,6 @@ namespace El {
 // The columns of these distributed matrices will be replicated on all 
 // processes (*), and the rows will be distributed like "Matrix Rows" (MR).
 // Thus the rows will be distributed among rows of the process grid.
-//template <typename T = double, El::DistNS::Dist U = MC, El::DistNS::Dist V = MR, El::DistWrapNS::DistWrap wrap = ELEMENT> class DistMatrix;
 
 template<typename T>
 class DistMatrix<T,STAR,MR> : public ElementalMatrix<T>
@@ -162,7 +161,6 @@ public:
     int PartialUnionRowRank() const EL_NO_EXCEPT override;
 
 private:
-    template<typename S,Dist U,Dist V,DistWrap wrap> friend class DistMatrix;
 };
 
 } // namespace El

--- a/include/El/core/DistMatrix/Element/STAR_STAR.hpp
+++ b/include/El/core/DistMatrix/Element/STAR_STAR.hpp
@@ -22,7 +22,6 @@ namespace El {
 // Partial specialization to A[* ,* ].
 //
 // The entire matrix is replicated across all processes.
-//template <typename T = double, El::DistNS::Dist U = MC, El::DistNS::Dist V = MR, El::DistWrapNS::DistWrap wrap = ELEMENT> class DistMatrix;
 
 template<typename T>
 class DistMatrix<T,STAR,STAR> : public ElementalMatrix<T>
@@ -160,7 +159,6 @@ public:
     int PartialUnionRowRank() const EL_NO_EXCEPT override;
 
 private:
-    template<typename S,Dist U,Dist V,DistWrap wrap> friend class DistMatrix;
 };
 
 } // namespace El

--- a/include/El/core/DistMatrix/Element/STAR_STAR.hpp
+++ b/include/El/core/DistMatrix/Element/STAR_STAR.hpp
@@ -9,11 +9,21 @@
 #ifndef EL_DISTMATRIX_ELEMENTAL_STAR_STAR_HPP
 #define EL_DISTMATRIX_ELEMENTAL_STAR_STAR_HPP
 
+#include <vector>
+
+#include "El/core/./DistMatrix/Abstract.hpp"
+#include "El/core/./DistMatrix/Element.hpp"
+#include "El/core/Grid.hpp"
+#include "El/core/imports/mpi.hpp"
+#include "El/core/types.hpp"
+
 namespace El {
 
 // Partial specialization to A[* ,* ].
 //
 // The entire matrix is replicated across all processes.
+//template <typename T = double, El::DistNS::Dist U = MC, El::DistNS::Dist V = MR, El::DistWrapNS::DistWrap wrap = ELEMENT> class DistMatrix;
+
 template<typename T>
 class DistMatrix<T,STAR,STAR> : public ElementalMatrix<T>
 {

--- a/include/El/core/DistMatrix/Element/STAR_VC.hpp
+++ b/include/El/core/DistMatrix/Element/STAR_VC.hpp
@@ -9,6 +9,14 @@
 #ifndef EL_DISTMATRIX_ELEMENTAL_STAR_VC_HPP
 #define EL_DISTMATRIX_ELEMENTAL_STAR_VC_HPP
 
+#include <vector>
+
+#include "El/core/./DistMatrix/Abstract.hpp"
+#include "El/core/./DistMatrix/Element.hpp"
+#include "El/core/Grid.hpp"
+#include "El/core/imports/mpi.hpp"
+#include "El/core/types.hpp"
+
 namespace El {
 
 // Partial specialization to A[* ,VC].
@@ -16,6 +24,8 @@ namespace El {
 // The rows of these distributed matrices are spread throughout the 
 // process grid in a column-major fashion, while the columns are not 
 // distributed.
+//template <typename T = double, El::DistNS::Dist U = MC, El::DistNS::Dist V = MR, El::DistWrapNS::DistWrap wrap = ELEMENT> class DistMatrix;
+
 template<typename T>
 class DistMatrix<T,STAR,VC> : public ElementalMatrix<T>
 {

--- a/include/El/core/DistMatrix/Element/STAR_VC.hpp
+++ b/include/El/core/DistMatrix/Element/STAR_VC.hpp
@@ -24,7 +24,6 @@ namespace El {
 // The rows of these distributed matrices are spread throughout the 
 // process grid in a column-major fashion, while the columns are not 
 // distributed.
-//template <typename T = double, El::DistNS::Dist U = MC, El::DistNS::Dist V = MR, El::DistWrapNS::DistWrap wrap = ELEMENT> class DistMatrix;
 
 template<typename T>
 class DistMatrix<T,STAR,VC> : public ElementalMatrix<T>
@@ -162,7 +161,6 @@ public:
     int PartialUnionRowRank() const EL_NO_EXCEPT override;
 
 private:
-    template<typename S,Dist U,Dist V,DistWrap wrap> friend class DistMatrix;
 };
 
 } // namespace El

--- a/include/El/core/DistMatrix/Element/STAR_VR.hpp
+++ b/include/El/core/DistMatrix/Element/STAR_VR.hpp
@@ -24,7 +24,6 @@ namespace El {
 // The rows of these distributed matrices are spread throughout the 
 // process grid in a row-major fashion, while the columns are not 
 // distributed.
-//template <typename T = double, El::DistNS::Dist U = MC, El::DistNS::Dist V = MR, El::DistWrapNS::DistWrap wrap = ELEMENT> class DistMatrix;
 
 template<typename T>
 class DistMatrix<T,STAR,VR> : public ElementalMatrix<T>
@@ -162,7 +161,6 @@ public:
     int PartialUnionRowRank() const EL_NO_EXCEPT override;
 
 private:
-    template<typename S,Dist U,Dist V,DistWrap wrap> friend class DistMatrix;
 };
 
 } // namespace El

--- a/include/El/core/DistMatrix/Element/STAR_VR.hpp
+++ b/include/El/core/DistMatrix/Element/STAR_VR.hpp
@@ -9,6 +9,14 @@
 #ifndef EL_DISTMATRIX_ELEMENTAL_STAR_VR_HPP
 #define EL_DISTMATRIX_ELEMENTAL_STAR_VR_HPP
 
+#include <vector>
+
+#include "El/core/./DistMatrix/Abstract.hpp"
+#include "El/core/./DistMatrix/Element.hpp"
+#include "El/core/Grid.hpp"
+#include "El/core/imports/mpi.hpp"
+#include "El/core/types.hpp"
+
 namespace El {
 
 // Partial specialization to A[* ,VR].
@@ -16,6 +24,8 @@ namespace El {
 // The rows of these distributed matrices are spread throughout the 
 // process grid in a row-major fashion, while the columns are not 
 // distributed.
+//template <typename T = double, El::DistNS::Dist U = MC, El::DistNS::Dist V = MR, El::DistWrapNS::DistWrap wrap = ELEMENT> class DistMatrix;
+
 template<typename T>
 class DistMatrix<T,STAR,VR> : public ElementalMatrix<T>
 {

--- a/include/El/core/DistMatrix/Element/VC_STAR.hpp
+++ b/include/El/core/DistMatrix/Element/VC_STAR.hpp
@@ -9,6 +9,14 @@
 #ifndef EL_DISTMATRIX_ELEMENTAL_VC_STAR_HPP
 #define EL_DISTMATRIX_ELEMENTAL_VC_STAR_HPP
 
+#include <vector>
+
+#include "El/core/./DistMatrix/Abstract.hpp"
+#include "El/core/./DistMatrix/Element.hpp"
+#include "El/core/Grid.hpp"
+#include "El/core/imports/mpi.hpp"
+#include "El/core/types.hpp"
+
 namespace El {
 
 // Partial specialization to A[VC,* ].
@@ -16,6 +24,8 @@ namespace El {
 // The columns of these distributed matrices are spread throughout the 
 // process grid in a column-major fashion, while the rows are not 
 // distributed.
+//template <typename T = double, El::DistNS::Dist U = MC, El::DistNS::Dist V = MR, El::DistWrapNS::DistWrap wrap = ELEMENT> class DistMatrix;
+
 template<typename T>
 class DistMatrix<T,VC,STAR> : public ElementalMatrix<T>
 {

--- a/include/El/core/DistMatrix/Element/VC_STAR.hpp
+++ b/include/El/core/DistMatrix/Element/VC_STAR.hpp
@@ -24,7 +24,6 @@ namespace El {
 // The columns of these distributed matrices are spread throughout the 
 // process grid in a column-major fashion, while the rows are not 
 // distributed.
-//template <typename T = double, El::DistNS::Dist U = MC, El::DistNS::Dist V = MR, El::DistWrapNS::DistWrap wrap = ELEMENT> class DistMatrix;
 
 template<typename T>
 class DistMatrix<T,VC,STAR> : public ElementalMatrix<T>
@@ -162,7 +161,6 @@ public:
     int PartialUnionRowRank() const EL_NO_EXCEPT override;
 
 private:
-    template<typename S,Dist U,Dist V,DistWrap wrap> friend class DistMatrix;
 };
 
 } // namespace El

--- a/include/El/core/DistMatrix/Element/VR_STAR.hpp
+++ b/include/El/core/DistMatrix/Element/VR_STAR.hpp
@@ -9,6 +9,14 @@
 #ifndef EL_DISTMATRIX_ELEMENTAL_VR_STAR_HPP
 #define EL_DISTMATRIX_ELEMENTAL_VR_STAR_HPP
 
+#include <vector>
+
+#include "El/core/./DistMatrix/Abstract.hpp"
+#include "El/core/./DistMatrix/Element.hpp"
+#include "El/core/Grid.hpp"
+#include "El/core/imports/mpi.hpp"
+#include "El/core/types.hpp"
+
 namespace El {
 
 // Partial specialization to A[VR,* ].
@@ -16,6 +24,9 @@ namespace El {
 // The columns of these distributed matrices are spread throughout the 
 // process grid in a row-major fashion, while the rows are not 
 // distributed.
+//template <typename T = double, El::DistNS::Dist U = MC, El::DistNS::Dist V = MR, El::DistWrapNS::DistWrap wrap = ELEMENT> class DistMatrix;
+
+
 template<typename T>
 class DistMatrix<T,VR,STAR> : public ElementalMatrix<T>
 {

--- a/include/El/core/DistMatrix/Element/VR_STAR.hpp
+++ b/include/El/core/DistMatrix/Element/VR_STAR.hpp
@@ -24,7 +24,6 @@ namespace El {
 // The columns of these distributed matrices are spread throughout the 
 // process grid in a row-major fashion, while the rows are not 
 // distributed.
-//template <typename T = double, El::DistNS::Dist U = MC, El::DistNS::Dist V = MR, El::DistWrapNS::DistWrap wrap = ELEMENT> class DistMatrix;
 
 
 template<typename T>
@@ -163,7 +162,6 @@ public:
     int PartialUnionRowRank() const EL_NO_EXCEPT override;
 
 private:
-    template<typename S,Dist U,Dist V,DistWrap wrap> friend class DistMatrix;
 };
 
 } // namespace El

--- a/include/El/core/DistMultiVec.hpp
+++ b/include/El/core/DistMultiVec.hpp
@@ -11,6 +11,13 @@
 #ifndef EL_CORE_DISTMULTIVEC_DECL_HPP
 #define EL_CORE_DISTMULTIVEC_DECL_HPP
 
+#include <vector>
+
+#include "El/core/./DistMatrix/Abstract.hpp"
+#include "El/core/Matrix.hpp"
+#include "El/core/imports/mpi.hpp"
+#include "El/core/types.hpp"
+
 namespace El {
 
 // Use a simple 1d distribution where each process owns a fixed number of rows,

--- a/include/El/core/DistSparseMatrix.hpp
+++ b/include/El/core/DistSparseMatrix.hpp
@@ -11,6 +11,15 @@
 #ifndef EL_CORE_DISTSPARSEMATRIX_DECL_HPP
 #define EL_CORE_DISTSPARSEMATRIX_DECL_HPP
 
+#include <functional>
+#include <vector>
+
+#include "El/core/DistGraph.hpp"
+#include "El/core/DistMap.hpp"
+#include "El/core/environment/impl.hpp"
+#include "El/core/imports/mpi.hpp"
+#include "El/core/types.hpp"
+
 namespace El {
 
 struct DistSparseMultMeta

--- a/include/El/core/Element/decl.hpp
+++ b/include/El/core/Element/decl.hpp
@@ -8,7 +8,7 @@
 */
 #ifndef EL_ELEMENT_DECL_HPP
 #define EL_ELEMENT_DECL_HPP
-
+#include <El/core/imports/mpc.hpp>
 namespace El {
 
 template<typename Real>

--- a/include/El/core/Element/impl.hpp
+++ b/include/El/core/Element/impl.hpp
@@ -8,6 +8,9 @@
 */
 #ifndef EL_ELEMENT_IMPL_HPP
 #define EL_ELEMENT_IMPL_HPP
+#include <ostream>
+#include <El/core/environment/decl.hpp>
+#include <El/core/imports/lapack.hpp>
 
 namespace El {
 
@@ -18,17 +21,17 @@ namespace El {
 // ---------------
 
 template<typename Real>
-ostream& operator<<( ostream& os, const Complex<Real>& alpha )
+std::ostream& operator<<( std::ostream& os, const Complex<Real>& alpha )
 {
     os << alpha.real() << "+" << alpha.imag() << "i";
     return os;
 }
 
 template<typename Real>
-istream& operator>>( istream& is, Complex<Real>& alpha )
+std::istream& operator>>( std::istream& is, Complex<Real>& alpha )
 {
     Real realPart, imagPart;
-    string token;
+    std::string token;
     std::stringstream tokenStream;
 
     // Grab the full token of the form "3+4i"

--- a/include/El/core/FlamePart/Merge.hpp
+++ b/include/El/core/FlamePart/Merge.hpp
@@ -9,10 +9,16 @@
 #ifndef EL_FLAMEPART_MERGE_HPP
 #define EL_FLAMEPART_MERGE_HPP
 
+#include "El/core/./DistMatrix/Element.hpp"
+#include "El/core/Matrix.hpp"
+#include "El/core/types.hpp"
+
 namespace El {
 
 // Horizontally merge two contiguous matrices
 // ==========================================
+//template <typename T = double, El::DistNS::Dist U = MC, El::DistNS::Dist V = MR, El::DistWrapNS::DistWrap wrap = ELEMENT> class DistMatrix;
+
 template<typename T>
 void Merge1x2( Matrix<T>& A, Matrix<T>& BL, Matrix<T>& BR );
 template<typename T>

--- a/include/El/core/FlamePart/Merge.hpp
+++ b/include/El/core/FlamePart/Merge.hpp
@@ -17,7 +17,6 @@ namespace El {
 
 // Horizontally merge two contiguous matrices
 // ==========================================
-//template <typename T = double, El::DistNS::Dist U = MC, El::DistNS::Dist V = MR, El::DistWrapNS::DistWrap wrap = ELEMENT> class DistMatrix;
 
 template<typename T>
 void Merge1x2( Matrix<T>& A, Matrix<T>& BL, Matrix<T>& BR );

--- a/include/El/core/FlamePart/Partition.hpp
+++ b/include/El/core/FlamePart/Partition.hpp
@@ -9,6 +9,10 @@
 #ifndef EL_FLAMEPART_PARTITION_HPP
 #define EL_FLAMEPART_PARTITION_HPP
 
+#include "El/core/./DistMatrix/Element.hpp"
+#include "El/core/Matrix.hpp"
+#include "El/core/environment/decl.hpp"
+
 namespace El {
 
 // Partition downwards from the top

--- a/include/El/core/FlamePart/Repartition.hpp
+++ b/include/El/core/FlamePart/Repartition.hpp
@@ -9,6 +9,10 @@
 #ifndef EL_FLAMEPART_REPARTITION_HPP
 #define EL_FLAMEPART_REPARTITION_HPP
 
+#include "El/core/./DistMatrix/Element.hpp"
+#include "El/core/Matrix.hpp"
+#include "El/core/environment/decl.hpp"
+
 namespace El {
 
 // To make our life easier. Undef'd at the bottom of the header

--- a/include/El/core/FlamePart/SlidePartition.hpp
+++ b/include/El/core/FlamePart/SlidePartition.hpp
@@ -9,6 +9,9 @@
 #ifndef EL_FLAMEPART_SLIDEPARTITION_HPP
 #define EL_FLAMEPART_SLIDEPARTITION_HPP
 
+#include "El/core/./DistMatrix/Element.hpp"
+#include "El/core/Matrix.hpp"
+
 namespace El {
 
 // To make our life easier. Undef'd at the bottom of the header

--- a/include/El/core/Graph.hpp
+++ b/include/El/core/Graph.hpp
@@ -11,7 +11,13 @@
 #ifndef EL_CORE_GRAPH_DECL_HPP
 #define EL_CORE_GRAPH_DECL_HPP
 
+#include <functional>
 #include <set>
+#include <utility>
+#include <vector>
+
+#include "El/core/imports/mpi.hpp"
+#include "El/core/types.hpp"
 
 namespace El {
 
@@ -20,9 +26,9 @@ using std::set;
 // Forward declaration
 class DistGraph;
 template<typename T>
-class SparseMatrix;
-template<typename T>
 class DistSparseMatrix;
+template<typename T>
+class SparseMatrix;
 
 class Graph
 {

--- a/include/El/core/Grid.hpp
+++ b/include/El/core/Grid.hpp
@@ -10,6 +10,13 @@
 #ifndef EL_GRID_HPP
 #define EL_GRID_HPP
 
+#include <ostream>
+#include <vector>
+
+#include "El/core/environment/decl.hpp"
+#include "El/core/imports/mpi.hpp"
+#include "El/core/types.hpp"
+
 namespace El {
 
 class Grid

--- a/include/El/core/Matrix.hpp
+++ b/include/El/core/Matrix.hpp
@@ -9,6 +9,12 @@
 #ifndef EL_MATRIX_HPP
 #define EL_MATRIX_HPP
 
+#include <vector>
+
+#include "El/core/Element/decl.hpp"
+#include "El/core/Memory.hpp"
+#include "El/core/types.hpp"
+
 namespace El {
 
 // Matrix base for arbitrary rings

--- a/include/El/core/Memory.hpp
+++ b/include/El/core/Memory.hpp
@@ -9,6 +9,8 @@
 #ifndef EL_MEMORY_HPP
 #define EL_MEMORY_HPP
 
+#include <stddef.h>
+
 namespace El {
 
 template<typename G>

--- a/include/El/core/Proxy.hpp
+++ b/include/El/core/Proxy.hpp
@@ -9,6 +9,13 @@
 #ifndef EL_CORE_PROXY_HPP
 #define EL_CORE_PROXY_HPP
 
+#include <exception>
+
+#include "El/core/./DistMatrix/Abstract.hpp"
+#include "El/core/Element/decl.hpp"
+#include "El/core/Matrix.hpp"
+#include "El/core/environment/decl.hpp"
+#include "El/core/types.hpp"
 // TODO: Split into several files
 
 namespace El {

--- a/include/El/core/Serialize.hpp
+++ b/include/El/core/Serialize.hpp
@@ -8,7 +8,7 @@
 */
 #ifndef EL_SERIALIZE_HPP
 #define EL_SERIALIZE_HPP
-
+#include <El/core/types.hpp>
 namespace El {
 
 #ifdef EL_HAVE_MPC

--- a/include/El/core/SparseMatrix.hpp
+++ b/include/El/core/SparseMatrix.hpp
@@ -11,6 +11,13 @@
 #ifndef EL_CORE_SPARSEMATRIX_DECL_HPP
 #define EL_CORE_SPARSEMATRIX_DECL_HPP
 
+#include <functional>
+#include <vector>
+
+#include "El/core/Graph.hpp"
+#include "El/core/imports/mpi.hpp"
+#include "El/core/types.hpp"
+
 namespace El {
 
 // Forward declaration for constructor

--- a/include/El/core/Timer.hpp
+++ b/include/El/core/Timer.hpp
@@ -10,6 +10,9 @@
 #define EL_TIMER_HPP
 
 #include <chrono>
+#include <iosfwd>
+
+#include "El/core/environment/decl.hpp"
 
 namespace El {
 

--- a/include/El/core/View.hpp
+++ b/include/El/core/View.hpp
@@ -28,7 +28,6 @@ namespace El {
 // (Sequential) matrix
 // -------------------
 
-//template <typename T = double, El::DistNS::Dist U = MC, El::DistNS::Dist V = MR, El::DistWrapNS::DistWrap wrap = ELEMENT> class DistMatrix;
 
 template<typename T>
 inline void View( Matrix<T>& A, Matrix<T>& B )

--- a/include/El/core/View.hpp
+++ b/include/El/core/View.hpp
@@ -9,6 +9,17 @@
 #ifndef EL_VIEW_HPP
 #define EL_VIEW_HPP
 
+#include <iosfwd>
+
+#include "El/core/./DistMatrix/Abstract.hpp"
+#include "El/core/./DistMatrix/Block.hpp"
+#include "El/core/./DistMatrix/Element.hpp"
+#include "El/core/DistMatrix.hpp"
+#include "El/core/Matrix.hpp"
+#include "El/core/environment/decl.hpp"
+#include "El/core/indexing/impl.hpp"
+#include "El/core/types.hpp"
+
 namespace El {
 
 // View an entire matrix
@@ -16,6 +27,8 @@ namespace El {
 
 // (Sequential) matrix
 // -------------------
+
+//template <typename T = double, El::DistNS::Dist U = MC, El::DistNS::Dist V = MR, El::DistWrapNS::DistWrap wrap = ELEMENT> class DistMatrix;
 
 template<typename T>
 inline void View( Matrix<T>& A, Matrix<T>& B )

--- a/include/El/core/environment/decl.hpp
+++ b/include/El/core/environment/decl.hpp
@@ -8,6 +8,9 @@
 */
 #ifndef EL_ENVIRONMENT_DECL_HPP
 #define EL_ENVIRONMENT_DECL_HPP
+#include <El/core/imports/mpi.hpp>
+#include <El/core/imports/choice.hpp>
+#include <El/core/imports/mpi_choice.hpp>
 
 namespace El {
 

--- a/include/El/core/imports/blas.hpp
+++ b/include/El/core/imports/blas.hpp
@@ -9,6 +9,10 @@
 #ifndef EL_IMPORTS_BLAS_HPP
 #define EL_IMPORTS_BLAS_HPP
 
+#include <complex>
+
+#include "El/core/Element/decl.hpp"
+
 namespace El {
 
 // NOTE: The EL_LAPACK macro is defined here since many of the BLAS overloads

--- a/include/El/core/imports/choice.hpp
+++ b/include/El/core/imports/choice.hpp
@@ -12,6 +12,13 @@
 #define EL_IMPORTS_CHOICE_HPP
 
 #include <algorithm>
+#include <iostream>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include "El/core/Element/decl.hpp"
+#include "El/core/imports/mpi.hpp"
 
 namespace El {
 

--- a/include/El/core/imports/lapack.hpp
+++ b/include/El/core/imports/lapack.hpp
@@ -9,6 +9,9 @@
 #ifndef EL_IMPORTS_LAPACK_HPP
 #define EL_IMPORTS_LAPACK_HPP
 
+#include "El/core/Element/decl.hpp"
+#include "El/core/imports/blas.hpp"
+
 namespace El {
 
 namespace lapack {

--- a/include/El/core/imports/mpi.h
+++ b/include/El/core/imports/mpi.h
@@ -8,6 +8,7 @@
 */
 #ifndef EL_IMPORTS_MPI_C_H
 #define EL_IMPORTS_MPI_C_H
+#include <El/core/types.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/El/core/imports/mpi.hpp
+++ b/include/El/core/imports/mpi.hpp
@@ -10,7 +10,18 @@
 #ifndef EL_IMPORTS_MPI_HPP
 #define EL_IMPORTS_MPI_HPP
 
+#include <algorithm>
+#include <complex>
+#include <functional>
+#include <vector>
+
+#include "El/core/Element/decl.hpp"
+#include "mpi.h"
+
 namespace El {
+
+template <typename Real> struct Entry;
+template <typename Real> struct ValueInt;
 
 using std::function;
 using std::vector;

--- a/include/El/core/imports/mpi_choice.hpp
+++ b/include/El/core/imports/mpi_choice.hpp
@@ -12,6 +12,13 @@
 #define EL_IMPORTS_MPICHOICE_HPP
 
 #include <algorithm>
+#include <iostream>
+#include <string>
+#include <vector>
+
+#include "El/core/Element/decl.hpp"
+#include "El/core/imports/choice.hpp"
+#include "El/core/imports/mpi.hpp"
 
 namespace El {
 namespace choice {

--- a/include/El/core/imports/pmrrr.hpp
+++ b/include/El/core/imports/pmrrr.hpp
@@ -9,6 +9,8 @@
 #ifndef EL_IMPORTS_PMRRR_HPP
 #define EL_IMPORTS_PMRRR_HPP
 
+#include "El/core/imports/mpi.hpp"
+
 namespace El {
 namespace herm_tridiag_eig {
 

--- a/include/El/core/imports/scalapack.hpp
+++ b/include/El/core/imports/scalapack.hpp
@@ -9,6 +9,10 @@
 #ifndef EL_IMPORTS_SCALAPACK_HPP
 #define EL_IMPORTS_SCALAPACK_HPP
 
+#include <ostream>
+
+#include "El/core/environment/decl.hpp"
+
 namespace El {
 
 inline void AssertScaLAPACKSupport()

--- a/include/El/core/indexing/impl.hpp
+++ b/include/El/core/indexing/impl.hpp
@@ -9,6 +9,10 @@
 #ifndef EL_INDEXING_IMPL_HPP
 #define EL_INDEXING_IMPL_HPP
 
+#include <ostream>
+
+#include "El/core/environment/decl.hpp"
+
 namespace El {
 
 // Indexing for element-wise distributions

--- a/include/El/core/limits.hpp
+++ b/include/El/core/limits.hpp
@@ -10,6 +10,10 @@
 #define EL_LIMITS_HPP
 
 #include <climits> // for INT_MIN et al. due to the Intel C++11 limitations
+#include <cmath>
+#include <limits>
+
+#include "El/core/Element/decl.hpp"
 
 namespace El {
 
@@ -24,6 +28,7 @@ struct IsFixedPrecision<BigFloat>
 
 template<typename Real>
 struct MantissaBits;
+
 template<> struct MantissaBits<float>
 { static const unsigned value = 24; };
 template<> struct MantissaBits<double>

--- a/include/El/core/types.hpp
+++ b/include/El/core/types.hpp
@@ -9,6 +9,12 @@
 #ifndef EL_TYPES_HPP
 #define EL_TYPES_HPP
 
+#include <iosfwd>
+#include <stdexcept>
+
+#include "El/core/Element/decl.hpp"
+#include "El/core/Element/impl.hpp"
+
 namespace El {
 
 template<typename T>

--- a/include/El/io.hpp
+++ b/include/El/io.hpp
@@ -9,7 +9,24 @@
 #ifndef EL_IO_HPP
 #define EL_IO_HPP
 
+#include <iostream>
+#include <vector>
+
+#include "El/core.hpp"
+#include "El/core/./DistMatrix/Abstract.hpp"
+#include "El/core/DistGraph.hpp"
+#include "El/core/Element/decl.hpp"
+#include "El/core/Graph.hpp"
+#include "El/core/Matrix.hpp"
+#include "El/core/environment/decl.hpp"
+#include "El/core/imports/mpi.hpp"
+#include "El/core/types.hpp"
+
 namespace El {
+
+template <typename T> class DistMultiVec;
+template <typename T> class DistSparseMatrix;
+template <typename T> class SparseMatrix;
 
 const char* QtImageFormat( FileFormat format );
 string FileExtension( FileFormat format );
@@ -53,9 +70,9 @@ void UpdateMaxImagWindowVal( double maxVal );
 } // namespace El
 
 #ifdef EL_HAVE_QT5
+# include "El/io/ComplexDisplayWindow-premoc.hpp"
 # include "El/io/DisplayWidget.hpp"
 # include "El/io/DisplayWindow-premoc.hpp"
-# include "El/io/ComplexDisplayWindow-premoc.hpp"
 #endif // ifdef EL_HAVE_QT5
 
 namespace El {
@@ -101,7 +118,10 @@ void Display( const DistSparseMatrix<T>& A, string title="DistSparseMatrix" );
 
 // Sparse-direct data structures
 // -----------------------------
-namespace ldl { struct DistNodeInfo; }
+namespace ldl {
+struct DistNodeInfo;
+}  // namespace ldl
+
 void DisplayLocal
 ( const ldl::DistNodeInfo& info, bool beforeFact, string title="" );
 

--- a/include/El/lapack_like/equilibrate.hpp
+++ b/include/El/lapack_like/equilibrate.hpp
@@ -9,10 +9,19 @@
 #ifndef EL_EQUILIBRATE_HPP
 #define EL_EQUILIBRATE_HPP
 
+#include "El/core.hpp"
+#include "El/core/./DistMatrix/Element.hpp"
+#include "El/core/Element/decl.hpp"
+#include "El/core/Matrix.hpp"
+
 namespace El {
 
 // Ruiz scaling
 // ============
+template <typename T> class DistMultiVec;
+template <typename T> class DistSparseMatrix;
+template <typename T> class SparseMatrix;
+
 template<typename F>
 void RuizEquil
 ( Matrix<F>& A,

--- a/include/El/lapack_like/euclidean_min.hpp
+++ b/include/El/lapack_like/euclidean_min.hpp
@@ -9,6 +9,11 @@
 #ifndef EL_EUCLIDEANMIN_HPP
 #define EL_EUCLIDEANMIN_HPP
 
+#include "El/core.hpp"
+#include "El/core/Element/decl.hpp"
+#include "El/core/Element/impl.hpp"
+#include "El/core/limits.hpp"
+#include "El/core/types.hpp"
 #include "El/lapack_like/factor.hpp"
 
 namespace El {
@@ -23,6 +28,10 @@ namespace El {
 //
 //    min_X || X ||_F s.t. op(A) X = B.
 //
+template <typename T> class DistMultiVec;
+template <typename T> class DistSparseMatrix;
+template <typename T> class SparseMatrix;
+
 template<typename F>
 void LeastSquares
 ( Orientation orientation, 

--- a/include/El/lapack_like/factor/ldl/sparse/symbolic/NodeInfo.hpp
+++ b/include/El/lapack_like/factor/ldl/sparse/symbolic/NodeInfo.hpp
@@ -11,6 +11,15 @@
 #ifndef EL_FACTOR_LDL_SPARSE_SYMBOLIC_NODEINFO_HPP
 #define EL_FACTOR_LDL_SPARSE_SYMBOLIC_NODEINFO_HPP
 
+#include <exception>
+#include <iostream>
+#include <vector>
+
+#include "El/core.hpp"
+#include "El/core/Grid.hpp"
+#include "El/core/environment/decl.hpp"
+#include "El/core/imports/mpi.hpp"
+
 namespace El {
 namespace ldl {
 

--- a/include/El/lapack_like/factor/ldl/sparse/symbolic/Separator.hpp
+++ b/include/El/lapack_like/factor/ldl/sparse/symbolic/Separator.hpp
@@ -22,6 +22,14 @@
 #ifndef EL_UTIL_SEPARATOR_HPP
 #define EL_UTIL_SEPARATOR_HPP
 
+#include <exception>
+#include <iostream>
+#include <vector>
+
+#include "El/core.hpp"
+#include "El/core/environment/decl.hpp"
+#include "El/core/imports/mpi.hpp"
+
 namespace El {
 namespace ldl {
 

--- a/include/El/lapack_like/perm.hpp
+++ b/include/El/lapack_like/perm.hpp
@@ -9,14 +9,20 @@
 #ifndef EL_PERM_HPP
 #define EL_PERM_HPP
 
-#include "perm/Permutation.hpp"
+#include "El/core.hpp"
+#include "El/core/./DistMatrix/Abstract.hpp"
+#include "El/core/Matrix.hpp"
+#include "El/core/types.hpp"
 #include "perm/DistPermutation.hpp"
+#include "perm/Permutation.hpp"
 
 namespace El {
 
 // Convert a pivot sequence to a partial permutation vector
 // ========================================================
 // NOTE: These routine are now deprecated
+template <typename T = double, El::DistNS::Dist U = MC, El::DistNS::Dist V = MR, El::DistWrapNS::DistWrap wrap = ELEMENT> class DistMatrix;
+
 void PivotsToPartialPermutation
 ( const Matrix<Int>& pivots,
         Matrix<Int>& p,

--- a/include/El/lapack_like/perm.hpp
+++ b/include/El/lapack_like/perm.hpp
@@ -21,7 +21,6 @@ namespace El {
 // Convert a pivot sequence to a partial permutation vector
 // ========================================================
 // NOTE: These routine are now deprecated
-template <typename T = double, El::DistNS::Dist U = MC, El::DistNS::Dist V = MR, El::DistWrapNS::DistWrap wrap = ELEMENT> class DistMatrix;
 
 void PivotsToPartialPermutation
 ( const Matrix<Int>& pivots,

--- a/include/El/lapack_like/perm/DistPermutation.hpp
+++ b/include/El/lapack_like/perm/DistPermutation.hpp
@@ -10,8 +10,22 @@
 #define EL_PERM_DISTPERMUTATION_HPP
 
 #include <map>
+#include <utility>
+#include <vector>
+
+#include "El/core.hpp"
+#include "El/core/./DistMatrix/Abstract.hpp"
+#include "El/core/./DistMatrix/Element.hpp"
+#include "El/core/./DistMatrix/Element/STAR_VC.hpp"
+#include "El/core/./DistMatrix/Element/VC_STAR.hpp"
+#include "El/core/Grid.hpp"
+#include "El/core/imports/mpi.hpp"
+#include "El/core/types.hpp"
 
 namespace El {
+
+class Permutation;
+template <typename T = double, El::DistNS::Dist U = MC, El::DistNS::Dist V = MR, El::DistWrapNS::DistWrap wrap = ELEMENT> class DistMatrix;
 
 struct PermutationMeta
 {

--- a/include/El/lapack_like/perm/DistPermutation.hpp
+++ b/include/El/lapack_like/perm/DistPermutation.hpp
@@ -25,7 +25,6 @@
 namespace El {
 
 class Permutation;
-template <typename T = double, El::DistNS::Dist U = MC, El::DistNS::Dist V = MR, El::DistWrapNS::DistWrap wrap = ELEMENT> class DistMatrix;
 
 struct PermutationMeta
 {

--- a/include/El/lapack_like/perm/Permutation.hpp
+++ b/include/El/lapack_like/perm/Permutation.hpp
@@ -9,6 +9,10 @@
 #ifndef EL_PERM_PERMUTATION_HPP
 #define EL_PERM_PERMUTATION_HPP
 
+#include "El/core.hpp"
+#include "El/core/Matrix.hpp"
+#include "El/core/types.hpp"
+
 namespace El {
 
 class Permutation

--- a/include/El/lapack_like/reflect.hpp
+++ b/include/El/lapack_like/reflect.hpp
@@ -9,6 +9,11 @@
 #ifndef EL_REFLECT_HPP
 #define EL_REFLECT_HPP
 
+#include "El/core.hpp"
+#include "El/core/./DistMatrix/Element.hpp"
+#include "El/core/Matrix.hpp"
+#include "El/core/types.hpp"
+
 namespace El {
 
 // ApplyPackedReflectors

--- a/include/El/lapack_like/solve.hpp
+++ b/include/El/lapack_like/solve.hpp
@@ -9,13 +9,24 @@
 #ifndef EL_SOLVE_HPP
 #define EL_SOLVE_HPP
 
-#include "El/lapack_like/factor.hpp"
+#include "El/core.hpp"
+#include "El/core/Element/decl.hpp"
+#include "El/core/types.hpp"
 #include "El/lapack_like/euclidean_min.hpp"
+#include "El/lapack_like/factor.hpp"
 
 namespace El {
 
 // Linear
 // ======
+struct BisectCtrl;
+template <typename Real> struct LDLPivotCtrl;
+template <typename Real> struct LeastSquaresCtrl;
+template <typename T = double, El::DistNS::Dist U = MC, El::DistNS::Dist V = MR, El::DistWrapNS::DistWrap wrap = ELEMENT> class DistMatrix;
+template <typename T> class DistMultiVec;
+template <typename T> class DistSparseMatrix;
+template <typename T> class SparseMatrix;
+
 template<typename F>
 void LinearSolve( const Matrix<F>& A, Matrix<F>& B );
 template<typename F>

--- a/include/El/lapack_like/solve.hpp
+++ b/include/El/lapack_like/solve.hpp
@@ -22,7 +22,6 @@ namespace El {
 struct BisectCtrl;
 template <typename Real> struct LDLPivotCtrl;
 template <typename Real> struct LeastSquaresCtrl;
-template <typename T = double, El::DistNS::Dist U = MC, El::DistNS::Dist V = MR, El::DistWrapNS::DistWrap wrap = ELEMENT> class DistMatrix;
 template <typename T> class DistMultiVec;
 template <typename T> class DistSparseMatrix;
 template <typename T> class SparseMatrix;

--- a/include/El/lapack_like/solve/FGMRES.hpp
+++ b/include/El/lapack_like/solve/FGMRES.hpp
@@ -9,6 +9,19 @@
 #ifndef EL_SOLVE_FGMRES_HPP
 #define EL_SOLVE_FGMRES_HPP
 
+#include <ostream>
+
+#include "El/core.hpp"
+#include "El/core/DistMultiVec.hpp"
+#include "El/core/Element/decl.hpp"
+#include "El/core/Element/impl.hpp"
+#include "El/core/Matrix.hpp"
+#include "El/core/Timer.hpp"
+#include "El/core/environment/decl.hpp"
+#include "El/core/imports/lapack.hpp"
+#include "El/core/imports/mpi.hpp"
+#include "El/core/limits.hpp"
+#include "El/core/types.hpp"
 // The pseudocode for Flexible GMRES can be found in "Algorithm 2.2" in
 //   Youcef Saad
 //   "A flexible inner-outer preconditioned GMRES algorithm"

--- a/include/El/lapack_like/solve/LGMRES.hpp
+++ b/include/El/lapack_like/solve/LGMRES.hpp
@@ -9,6 +9,18 @@
 #ifndef EL_SOLVE_LGMRES_HPP
 #define EL_SOLVE_LGMRES_HPP
 
+#include <ostream>
+
+#include "El/core.hpp"
+#include "El/core/DistMultiVec.hpp"
+#include "El/core/Element/decl.hpp"
+#include "El/core/Element/impl.hpp"
+#include "El/core/Matrix.hpp"
+#include "El/core/environment/decl.hpp"
+#include "El/core/imports/lapack.hpp"
+#include "El/core/imports/mpi.hpp"
+#include "El/core/limits.hpp"
+#include "El/core/types.hpp"
 // TODO: Add support for promotion?
 
 namespace El {

--- a/include/El/lapack_like/solve/Refined.hpp
+++ b/include/El/lapack_like/solve/Refined.hpp
@@ -9,6 +9,15 @@
 #ifndef EL_SOLVE_REFINED_HPP
 #define EL_SOLVE_REFINED_HPP
 
+#include <ostream>
+
+#include "El/core.hpp"
+#include "El/core/DistMultiVec.hpp"
+#include "El/core/Element/decl.hpp"
+#include "El/core/Matrix.hpp"
+#include "El/core/environment/decl.hpp"
+#include "El/core/imports/mpi.hpp"
+#include "El/core/types.hpp"
 // The following routines each have three underlying implementations:
 //
 //  1) a single right-hand side,

--- a/include/El/lapack_like/spectral/Lanczos.hpp
+++ b/include/El/lapack_like/spectral/Lanczos.hpp
@@ -9,6 +9,22 @@
 #ifndef EL_SPECTRAL_LANCZOS_HPP
 #define EL_SPECTRAL_LANCZOS_HPP
 
+#include <iosfwd>
+
+#include "El/core.hpp"
+#include "El/core/./DistMatrix/Element.hpp"
+#include "El/core/DistMultiVec.hpp"
+#include "El/core/Element/decl.hpp"
+#include "El/core/Element/impl.hpp"
+#include "El/core/Matrix.hpp"
+#include "El/core/Proxy.hpp"
+#include "El/core/environment/decl.hpp"
+#include "El/core/imports/mpi.hpp"
+#include "El/core/indexing/impl.hpp"
+#include "El/core/limits.hpp"
+#include "El/core/random/impl.hpp"
+#include "El/core/types.hpp"
+
 namespace El {
 
 // Form 

--- a/include/El/lapack_like/spectral/ProductLanczos.hpp
+++ b/include/El/lapack_like/spectral/ProductLanczos.hpp
@@ -9,6 +9,16 @@
 #ifndef EL_SPECTRAL_PRODUCT_LANCZOS_HPP
 #define EL_SPECTRAL_PRODUCT_LANCZOS_HPP
 
+#include <iosfwd>
+
+#include "El/core.hpp"
+#include "El/core/./DistMatrix/Element.hpp"
+#include "El/core/DistMultiVec.hpp"
+#include "El/core/Element/decl.hpp"
+#include "El/core/Matrix.hpp"
+#include "El/core/environment/decl.hpp"
+#include "El/core/imports/mpi.hpp"
+
 namespace El {
 
 template<typename F,class ApplyAType,class ApplyAAdjType>

--- a/include/El/matrices.hpp
+++ b/include/El/matrices.hpp
@@ -9,6 +9,16 @@
 #ifndef EL_MATRICES_HPP
 #define EL_MATRICES_HPP
 
+#include <functional>
+#include <vector>
+
+#include "El/core.hpp"
+#include "El/core/./DistMatrix/Abstract.hpp"
+#include "El/core/./DistMatrix/Element.hpp"
+#include "El/core/Element/decl.hpp"
+#include "El/core/Matrix.hpp"
+#include "El/core/imports/mpi.hpp"
+
 namespace El {
 
 // Deterministic
@@ -19,6 +29,10 @@ namespace El {
 
 // Cauchy
 // ------
+template <typename T> class DistMultiVec;
+template <typename T> class DistSparseMatrix;
+template <typename T> class SparseMatrix;
+
 template<typename F1,typename F2>
 void Cauchy
 ( Matrix<F1>& A, const vector<F2>& x, const vector<F2>& y );

--- a/include/El/optimization/prox.hpp
+++ b/include/El/optimization/prox.hpp
@@ -23,7 +23,6 @@ namespace El {
 
 // Clipping
 // --------
-template <typename T = double, El::DistNS::Dist U = MC, El::DistNS::Dist V = MR, El::DistWrapNS::DistWrap wrap = ELEMENT> class DistMatrix;
 template <typename T> class DistMultiVec;
 
 template<typename Real>

--- a/include/El/optimization/prox.hpp
+++ b/include/El/optimization/prox.hpp
@@ -9,6 +9,13 @@
 #ifndef EL_OPTIMIZATION_PROX_HPP
 #define EL_OPTIMIZATION_PROX_HPP
 
+#include "El/core.hpp"
+#include "El/core/./DistMatrix/Abstract.hpp"
+#include "El/core/./DistMatrix/Element.hpp"
+#include "El/core/Element/decl.hpp"
+#include "El/core/Matrix.hpp"
+#include "El/core/types.hpp"
+
 namespace El {
 
 // Proximal maps
@@ -16,6 +23,9 @@ namespace El {
 
 // Clipping
 // --------
+template <typename T = double, El::DistNS::Dist U = MC, El::DistNS::Dist V = MR, El::DistWrapNS::DistWrap wrap = ELEMENT> class DistMatrix;
+template <typename T> class DistMultiVec;
+
 template<typename Real>
 void LowerClip( Matrix<Real>& X, Real lowerBound=0 );
 template<typename Real>

--- a/include/El/optimization/util.hpp
+++ b/include/El/optimization/util.hpp
@@ -12,6 +12,10 @@
 #include "./util/cone.hpp"
 #include "./util/pos_orth.hpp"
 #include "./util/soc.hpp"
+#include "El/core/./DistMatrix/Element.hpp"
+#include "El/core/Element/decl.hpp"
+#include "El/core/Matrix.hpp"
+#include "El/core/types.hpp"
 
 namespace El {
 

--- a/include/El/optimization/util/cone.hpp
+++ b/include/El/optimization/util/cone.hpp
@@ -9,6 +9,18 @@
 #ifndef EL_OPTIMIZATION_UTIL_CONE_HPP
 #define EL_OPTIMIZATION_UTIL_CONE_HPP
 
+#include "El/core.hpp"
+#include "El/core/./DistMatrix/Element.hpp"
+#include "El/core/Element/decl.hpp"
+#include "El/core/Matrix.hpp"
+#include "El/core/imports/mpi.hpp"
+
+namespace El {
+template <typename T> class DistMultiVec;
+template <typename T> class DistSparseMatrix;
+template <typename T> class SparseMatrix;
+}  // namespace El
+
 namespace El {
 namespace cone {
 

--- a/include/El/optimization/util/pos_orth.hpp
+++ b/include/El/optimization/util/pos_orth.hpp
@@ -9,6 +9,20 @@
 #ifndef EL_OPTIMIZATION_UTIL_POS_ORTH_HPP
 #define EL_OPTIMIZATION_UTIL_POS_ORTH_HPP
 
+#include <limits>
+
+#include "El/core.hpp"
+#include "El/core/./DistMatrix/Abstract.hpp"
+#include "El/core/./DistMatrix/Element.hpp"
+#include "El/core/Element/decl.hpp"
+#include "El/core/Matrix.hpp"
+
+namespace El {
+template <typename T> class DistMultiVec;
+template <typename T> class DistSparseMatrix;
+template <typename T> class SparseMatrix;
+}  // namespace El
+
 namespace El {
 namespace pos_orth {
 

--- a/include/El/optimization/util/soc.hpp
+++ b/include/El/optimization/util/soc.hpp
@@ -9,6 +9,17 @@
 #ifndef EL_OPTIMIZATION_UTIL_SOC_HPP
 #define EL_OPTIMIZATION_UTIL_SOC_HPP
 
+#include <limits>
+
+#include "El/core.hpp"
+#include "El/core/./DistMatrix/Element.hpp"
+#include "El/core/Element/decl.hpp"
+#include "El/core/Matrix.hpp"
+
+namespace El {
+template <typename T> class DistMultiVec;
+}  // namespace El
+
 namespace El {
 namespace soc {
 


### PR DESCRIPTION
used the tool "include what you use" to make each header include the things that it uses directly, with a bias towards forward declarations.