### PR TITLE
Fixing args for MKL Trrk & xgemmt routines

### DIFF
--- a/src/blas_like/level3/Trrk.cpp
+++ b/src/blas_like/level3/Trrk.cpp
@@ -49,9 +49,11 @@ void TrrkMKL
     const char uploChar = UpperOrLowerToChar( uplo );
     const char orientAChar = OrientationToChar( orientA );
     const char orientBChar = OrientationToChar( orientB );
-
+    const auto n = C.Height();
+    const auto k = orientA == NORMAL ? A.Width() : A.Height(); 
     mkl::Trrk 
     ( uploChar, orientAChar, orientBChar,
+      n, k, 
       alpha, A.LockedBuffer(), A.LDim(),
              B.LockedBuffer(), B.LDim(),
       beta,  C.Buffer(),       C.LDim() );

--- a/src/core/imports/mkl.cpp
+++ b/src/core/imports/mkl.cpp
@@ -404,6 +404,7 @@ void Trrk
 {
     EL_BLAS(sgemmt)
     ( &uplo, &transA, &transB,
+      &n, &k,
       &alpha, A, &ALDim, B, &BLDim,
       &beta,  C, &CLDim );
 }
@@ -418,6 +419,7 @@ void Trrk
 {
     EL_BLAS(dgemmt)
     ( &uplo, &transA, &transB,
+      &n, &k,
       &alpha, A, &ALDim, B, &BLDim,
       &beta,  C, &CLDim );
 }
@@ -432,6 +434,7 @@ void Trrk
 {
     EL_BLAS(cgemmt)
     ( &uplo, &transA, &transB,
+      &n, &k,
       &alpha, A, &ALDim, B, &BLDim,
       &beta,  C, &CLDim );
 }
@@ -446,6 +449,7 @@ void Trrk
 {
     EL_BLAS(zgemmt)
     ( &uplo, &transA, &transB,
+      &n, &k,
       &alpha, A, &ALDim, B, &BLDim,
       &beta,  C, &CLDim );
 }


### PR DESCRIPTION
Note that the xgemmt routines only work for mkl 2016. Older versions fail when linking the library. 