### PR TITLE
Test with Clang. Test on Ubuntu 14.04 to get MPICH 3. Use ccache to speed up tests.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,16 @@
+sudo: required
+dist: trusty
+
+notifications:
+  email: false
+
 language: generic
 
 env:
   global:
-    - MPI=mpich2
+    - MPI=mpich
     - F77=gfortran-5
+    - PATH=/usr/lib/ccache/:$PATH
 #  - MPI=openmpi
 # Open MPI is disabled until there is a way to install a reasonably recent
 # version, as 1.6.5 is known to have bugs that lead to incorrect behavior in
@@ -14,16 +21,19 @@ env:
     - CC=gcc-5 CXX=g++-5
     - CC=clang-3.8 CXX=clang++-3.8
 
-notifications:
-  email: false
+cache:
+  directories:
+    - $HOME/.ccache
 
 addons:
   apt:
     sources:
       - sourceline: 'ppa:ubuntu-toolchain-r/test'
-      - sourceline: 'deb http://apt.llvm.org/precise/ llvm-toolchain-precise-3.8 main'
+      - sourceline: 'deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty-3.8 main'
         key_url: http://apt.llvm.org/llvm-snapshot.gpg.key
+      - sourceline: 'ppa:dzombie/ccache'
     packages:
+      - ccache
       - gcc-5
       - g++-5
       - gfortran-5
@@ -31,15 +41,19 @@ addons:
       - clang-3.8
 
 install:
+  - sudo ln -s /usr/bin/ccache /usr/lib/ccache/clang-3.8
+  - sudo ln -s /usr/bin/ccache /usr/lib/ccache/clang++-3.8
+  - echo `which $CC`
+  - echo `which $CXX`
   - sh travis/install-mpi.sh $MPI
-  - curl https://cmake.org/files/v3.3/cmake-3.3.2-Linux-x86_64.tar.gz | sudo tar -x -z --strip-components 1 -C /usr
-
-before_script:
-  - sudo hostname localhost
+  - curl https://cmake.org/files/v3.6/cmake-3.6.1-Linux-x86_64.tar.gz | sudo tar -x -z --strip-components 1 -C /usr
 
 script:
+  - sudo ln -s /usr/bin/ccache /usr/lib/ccache/clang-3.8
+  - sudo ln -s /usr/bin/ccache /usr/lib/ccache/clang++-3.8
+  - echo `which $CC`
+  - echo `which $CXX`
   - mkdir build && cd build;
     cmake -DEL_TESTS=ON -DEL_EXAMPLES=ON -DCMAKE_CXX_COMPILER=$CXX -DCMAKE_C_COMPILER=$CC -DCMAKE_Fortran_COMPILER=$F77 -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=~/Install .. ;
     if test $? -ne 0; then cat CMakeFiles/CMakeError.log; fi
   - make -j2 && sudo make install && sudo ctest --output-on-failure
-

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,59 +1,45 @@
-language: cpp
-
-compiler:
-  # - clang
-  - gcc
+language: generic
 
 env:
-  - MPI=mpich2
+  global:
+    - MPI=mpich2
+    - F77=gfortran-5
 #  - MPI=openmpi
 # Open MPI is disabled until there is a way to install a reasonably recent
 # version, as 1.6.5 is known to have bugs that lead to incorrect behavior in
 # Elemental for complex data despite attempts at performing soft casts
 # to twice as many entries of real data (with the exact cause unfortunately
 # currently unknown)
-
-# matrix:
-#   exclude:
-#     - env: MPI=mpich2
-#       compiler: clang
+  matrix:
+    - CC=gcc-5 CXX=g++-5
+    - CC=clang-3.8 CXX=clang++-3.8
 
 notifications:
   email: false
 
+addons:
+  apt:
+    sources:
+      - sourceline: 'ppa:ubuntu-toolchain-r/test'
+      - sourceline: 'deb http://apt.llvm.org/precise/ llvm-toolchain-precise-3.8 main'
+        key_url: http://apt.llvm.org/llvm-snapshot.gpg.key
+    packages:
+      - gcc-5
+      - g++-5
+      - gfortran-5
+      - libstdc++-5-dev
+      - clang-3.8
 
 install:
-  # - sudo add-apt-repository -y ppa:staticfloat/julia-deps
-  - sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
-  # - echo deb http://llvm.org/apt/precise/ llvm-toolchain-precise main | sudo tee -a /etc/apt/sources.list
-  # - curl http://llvm.org/apt/llvm-snapshot.gpg.key | sudo apt-key add -
-  - sudo apt-get update -qq -y
-  - sudo apt-get install -qq -y gcc-5 g++-5 gfortran-5 libstdc++-5-dev
-  # clang-3.7
-  # lcov
   - sh travis/install-mpi.sh $MPI
-  # - sudo pip install cpp-coveralls
   - curl https://cmake.org/files/v3.3/cmake-3.3.2-Linux-x86_64.tar.gz | sudo tar -x -z --strip-components 1 -C /usr
-  # - curl http://ftp.de.debian.org/debian/pool/main/l/lcov/lcov_1.11.orig.tar.gz | tar xz
-  # - sudo make -j2 -C lcov-1.11/ install
-  # - gem install coveralls-lcov
 
 before_script:
-  # - if test x$CC = xclang; then export CC=clang-3.7; export CXX=clang++-3.7; export F77=gfortran-4.9; fi
-  - if test x$CC = xgcc; then export CC=gcc-5; export CXX=g++-5; export F77=gfortran-5; fi
   - sudo hostname localhost
-  - test $MPI == mpich2 && MPIEXEC='mpiexec -launcher fork' || true
-  # - lcov --directory . --zerocounters
 
 script:
   - mkdir build && cd build;
     cmake -DEL_TESTS=ON -DEL_EXAMPLES=ON -DCMAKE_CXX_COMPILER=$CXX -DCMAKE_C_COMPILER=$CC -DCMAKE_Fortran_COMPILER=$F77 -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=~/Install .. ;
     if test $? -ne 0; then cat CMakeFiles/CMakeError.log; fi
   - make -j2 && sudo make install && sudo ctest --output-on-failure
-
-after_success:
-  # - lcov --directory . --capture --output-file coverage.info # capture coverage info
-  # - lcov --remove coverage.info 'tests/*' '/usr/*' --output-file coverage.info # filter out system and test code
-  # - lcov --list coverage.info # debug before upload
-  # - coveralls-lcov --repo-token orrZO32nywoXo9Y70QEcCJ3M8v00QVOaC coverage.info # uploads to coveralls
 

--- a/travis/install-mpi.sh
+++ b/travis/install-mpi.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
 set -e
 case $1 in
-  mpich2) set -x;
-    sudo apt-get install -q mpich2 libmpich2-3 libmpich2-dev;;
+  mpich) set -x;
+    sudo apt-get install -q mpich libmpich-dev;;
   openmpi) set -x;
     sudo apt-get install openmpi-bin openmpi-dev;;
   *)


### PR DESCRIPTION
It took a while for me to figure out how to set up `ccache` on Travis but it seems to work now. Build times are down to 10-15 minutes. This will probably also make it possible to test with a recent version of OpenMPI which requires that we build it first.