### PR TITLE
Temporarily disable tests while building up the cache on Travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,4 +56,5 @@ script:
   - mkdir build && cd build;
     cmake -DEL_TESTS=ON -DEL_EXAMPLES=ON -DCMAKE_CXX_COMPILER=$CXX -DCMAKE_C_COMPILER=$CC -DCMAKE_Fortran_COMPILER=$F77 -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=~/Install .. ;
     if test $? -ne 0; then cat CMakeFiles/CMakeError.log; fi
-  - make -j2 && sudo make install && sudo ctest --output-on-failure
+  - make -j2
+  # && sudo make install && sudo ctest --output-on-failure


### PR DESCRIPTION
Test should be reenabled as soon as both the GCC and Clang builds have succeeded
on the master branch.