### PR TITLE
Revert "Temporarily disable tests while building up the cache on Travis. Test"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,5 +56,4 @@ script:
   - mkdir build && cd build;
     cmake -DEL_TESTS=ON -DEL_EXAMPLES=ON -DCMAKE_CXX_COMPILER=$CXX -DCMAKE_C_COMPILER=$CC -DCMAKE_Fortran_COMPILER=$F77 -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=~/Install .. ;
     if test $? -ne 0; then cat CMakeFiles/CMakeError.log; fi
-  - make -j2
-  # && sudo make install && sudo ctest --output-on-failure
+  - make -j2 && sudo make install && sudo ctest --output-on-failure


### PR DESCRIPTION
This reverts commit 8e391aabe5201ce0052b6e352ca88d78a6168b27.

The build on master succeeded so now the tests can be reenabled. Now let's test if this caching works for new PRs. If things work the way I planned then this PR should finish fairly fast, i.e. about 15 minutes.