### PR TITLE
use gnuinstalldirs properly

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,6 +57,7 @@ if(BUILD_SHARED_LIBS AND NOT SUPPORTS_SHARED)
   set(BUILD_SHARED_LIBS OFF CACHE BOOL "Build shared libraries?")
 endif()
 
+include(GNUInstallDirs)
 if(NOT CMAKE_INSTALL_INCLUDEDIR)
   set(CMAKE_INSTALL_INCLUDEDIR "include")
 endif()


### PR DESCRIPTION
we needed to include this module apparently to make the variables all work correctly.