### PR TITLE
fix QT bug when running tests without X11

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -621,7 +621,7 @@ if(EL_LINK_FLAGS)
   set_target_properties(sandbox-test PROPERTIES LINK_FLAGS ${EL_LINK_FLAGS})
 endif()
 add_test(NAME sandbox/test WORKING_DIRECTORY "${PROJECT_BINARY_DIR}/bin"
-  COMMAND sandbox-test)
+  COMMAND sandbox-test -platform offscreen)
 
 # Test drivers
 # ------------
@@ -657,7 +657,7 @@ if(EL_TESTS)
       install(TARGETS tests-${TYPE}-${TESTNAME} DESTINATION ${CMAKE_INSTALL_BINDIR}/${TEST_INSTALL_DIR})
       if(NOT TESTNAME STREQUAL "SparseLDLRange") #Skip tests that can time out
         add_test(NAME Tests/${TYPE}/${TESTNAME} 
-          WORKING_DIRECTORY "${TEST_DIR}" COMMAND tests-${TYPE}-${TESTNAME})
+          WORKING_DIRECTORY "${TEST_DIR}" COMMAND tests-${TYPE}-${TESTNAME} -platform offscreen)
       endif()
     endforeach()
   endforeach()
@@ -706,7 +706,7 @@ if(EL_EXAMPLES)
       install(TARGETS examples-${TYPE}-${EXNAME}
 	      DESTINATION ${CMAKE_INSTALL_BINDIR}/${EXAMPLE_INSTALL_DIR})
       add_test(NAME Examples/${TYPE}/${EXNAME} WORKING_DIRECTORY "${OUTPUT_DIR}"
-        COMMAND examples-${TYPE}-${EXNAME})
+        COMMAND examples-${TYPE}-${EXNAME} -platform offscreen)
     endforeach()
   endforeach()
 endif()


### PR DESCRIPTION
It appears that when QT is enabled in the build it is possible for tests to fail. Adding this option allows the tests to not fail when QT is enabled. I've tested that this fixes the problem I was experiencing:

`[rpmbuild@9e172a3d127e blas_like]$ ./tests-blas_like-Gemm_openmpi 
QXcbConnection: Could not connect to display 
[9e172a3d127e:06979] *** Process received signal ***
[9e172a3d127e:06979] Signal: Aborted (6)
[9e172a3d127e:06979] Signal code:  (-6)
[9e172a3d127e:06979] [ 0] /lib64/libpthread.so.0(+0x10c30)[0x7f2b821bac30]
[9e172a3d127e:06979] [ 1] /lib64/libc.so.6(gsignal+0x35)[0x7f2b81e1c6f5]
[9e172a3d127e:06979] [ 2] /lib64/libc.so.6(abort+0x16a)[0x7f2b81e1e2fa]
[9e172a3d127e:06979] [ 3] /lib64/libQt5Core.so.5(+0x91471)[0x7f2b82cff471]
[9e172a3d127e:06979] [ 4] /lib64/libQt5XcbQpa.so.5(_ZN14QXcbConnectionC1EP19QXcbNativeInterfacebjPKc+0x9a7)[0x7f2b8a9b45f7]
[9e172a3d127e:06979] [ 5] /lib64/libQt5XcbQpa.so.5(_ZN15QXcbIntegrationC1ERK11QStringListRiPPc+0x32e)[0x7f2b8a9b74ce]
[9e172a3d127e:06979] [ 6] /usr/lib64/qt5/plugins/platforms/libqxcb.so(+0x171d)[0x7f2b8ab4271d]
[9e172a3d127e:06979] [ 7] /lib64/libQt5Gui.so.5(_ZN27QPlatformIntegrationFactory6createERK7QStringRK11QStringListRiPPcS2_+0x11d)[0x7f2b831d939d]
[9e172a3d127e:06979] [ 8] /lib64/libQt5Gui.so.5(_ZN22QGuiApplicationPrivate25createPlatformIntegrationEv+0x421)[0x7f2b831e6c71]
[9e172a3d127e:06979] [ 9] /lib64/libQt5Gui.so.5(_ZN22QGuiApplicationPrivate21createEventDispatcherEv+0x2d)[0x7f2b831e7bcd]
[9e172a3d127e:06979] [10] /lib64/libQt5Core.so.5(_ZN23QCoreApplicationPrivate4initEv+0x819)[0x7f2b82eb7ac9]
[9e172a3d127e:06979] [11] /lib64/libQt5Gui.so.5(_ZN22QGuiApplicationPrivate4initEv+0x2e)[0x7f2b831e8f1e]
[9e172a3d127e:06979] [12] /lib64/libQt5Widgets.so.5(_ZN19QApplicationPrivate4initEv+0x9)[0x7f2b83747449]
[9e172a3d127e:06979] [13] /home/rpmbuild/rpmbuild/BUILD/Elemental-master/openmpi-x86_64/libEl_openmpi.so(_ZN2El13InitializeQt5ERiRPPc+0x141)[0x7f2b87ffc211]
[9e172a3d127e:06979] [14] /home/rpmbuild/rpmbuild/BUILD/Elemental-master/openmpi-x86_64/libEl_openmpi.so(_ZN2El10InitializeERiRPPc+0x181)[0x7f2b88081ab1]
[9e172a3d127e:06979] [15] ./tests-blas_like-Gemm_openmpi(main+0x43)[0x5650abea3223]
[9e172a3d127e:06979] [16] /lib64/libc.so.6(__libc_start_main+0xf1)[0x7f2b81e08731]
[9e172a3d127e:06979] [17] ./tests-blas_like-Gemm_openmpi(_start+0x29)[0x5650abea4339]
[9e172a3d127e:06979] *** End of error message ***`

I have not checked what happens when this option is used and QT is disabled