### PR TITLE
Fixed an example not building on 64-bit Ints.

### DIFF
--- a/examples/core/Arbitrary.cpp
+++ b/examples/core/Arbitrary.cpp
@@ -2,14 +2,14 @@
    Copyright (c) 2009-2016, Jack Poulson
    All rights reserved.
 
-   This file is part of Elemental and is under the BSD 2-Clause License, 
-   which can be found in the LICENSE file in the root directory, or at 
+   This file is part of Elemental and is under the BSD 2-Clause License,
+   which can be found in the LICENSE file in the root directory, or at
    http://opensource.org/licenses/BSD-2-Clause
 */
 #include <El.hpp>
 using namespace El;
 
-int 
+int
 main( int argc, char* argv[] )
 {
     Environment env( argc, argv );
@@ -40,9 +40,9 @@ main( int argc, char* argv[] )
         if( mpi::Rank(comm) == 0 )
         {
             for( Int j=0; j<numRows; ++j )
-                rowInds[j] = SampleUniform(0,n);
+                rowInds[j] = SampleUniform(Int(0),n);
             for( Int j=0; j<numCols; ++j )
-                colInds[j] = SampleUniform(0,n);
+                colInds[j] = SampleUniform(Int(0),n);
         }
         mpi::Broadcast( rowInds.data(), numRows, 0, comm );
         mpi::Broadcast( colInds.data(), numCols, 0, comm );
@@ -57,20 +57,20 @@ main( int argc, char* argv[] )
                 std::cout << colInds[j] << "\n";
             std::cout << std::endl;
         }
-        
+
         auto ASub =  A( rowInds, colInds );
         if( display )
             Display( ASub, "ASub" );
         if( print )
             Print( ASub, "ASub" );
-      
+
         MakeUniform( ASub );
         if( display )
             Display( ASub, "Scrambled ASub" );
         if( print )
             Print( ASub, "Scrambled ASub" );
         SetSubmatrix( A, rowInds, colInds, ASub );
-       
+
         if( display )
             Display( A, "Modified Fourier matrix" );
         if( print )


### PR DESCRIPTION
When not building on 64-bit `El::Ints`, the `0` literal is an `int`, which is of the same type as `El::Int`, but runs into issues when they are different types when using 64-bit `El::Ints` through `-DEL_USE_64BIT_BLAS_INTS=ON`. This fixes it with a simple cast.