### PR TITLE
Adding missing sequential dense equilibration implementations

### DIFF
--- a/examples/optimization/RandomFeasibleLP.cpp
+++ b/examples/optimization/RandomFeasibleLP.cpp
@@ -1,0 +1,92 @@
+/*
+   Copyright (c) 2009-2016, Jack Poulson
+   All rights reserved.
+
+   This file is part of Elemental and is under the BSD 2-Clause License,
+   which can be found in the LICENSE file in the root directory, or at
+   http://opensource.org/licenses/BSD-2-Clause
+*/
+#include <El.hpp>
+
+template<typename Real>
+void RandomFeasibleLP( El::Int m, El::Int n, El::Int k )
+{
+    El::Output("Testing with ",El::TypeName<Real>());
+    // Create random (primal feasible) inputs for the primal/dual problem
+    //    arginf_{x,s} { c^T x | A x = b, G x + s = h, s >= 0 }
+    //    argsup_{y,z} { -b^T y - h^T z | A^T y + G^T z + c = 0, z >= 0 }.
+
+    // xFeas and sFeas are only used for problem generation
+    El::Matrix<Real> xFeas, sFeas;
+    El::Uniform( xFeas, n, 1 ); // Sample over B_1(0)
+    El::Uniform( sFeas, k, 1, Real(1), Real(1) ); // Sample over B_1(1)
+
+    El::Matrix<Real> A, G, b, c, h;
+    El::Uniform( A, m, n );
+    El::Uniform( G, k, n );
+    El::Gemv( El::NORMAL, Real(1), A, xFeas, b );
+    El::Gemv( El::NORMAL, Real(1), G, xFeas, h );
+    h += sFeas;
+    El::Uniform( c, n, 1 );
+  
+    // Solve the primal/dual Linear Program with the default options
+    El::Matrix<Real> x, y, z, s;
+    El::LP( A, G, b, c, h, x, y, z, s );
+  
+    // Print the primal and dual objective values
+    const Real primal = El::Dot(c,x);
+    const Real dual = -El::Dot(b,y) - El::Dot(h,z);
+    El::Output("c^T x = ",primal);
+    El::Output("-b^T y - h^T z = ",dual);
+  
+    // Print the relative primal feasibility residual,
+    //   || A x - b ||_2 / max( || b ||_2, 1 ).
+    El::Matrix<Real> rPrimal;
+    El::Gemv( El::NORMAL, Real(1), A, x, rPrimal );
+    rPrimal -= b;
+    const Real bFrob = El::FrobeniusNorm( b );
+    const Real rPrimalFrob = El::FrobeniusNorm( rPrimal );
+    const Real primalRelResid = rPrimalFrob / El::Max( bFrob, Real(1) );
+    El::Output("|| A x - b ||_2 / || b ||_2 = ",primalRelResid);
+  
+    // Print the relative dual feasiability residual,
+    //   || A^T y + G^T z + c ||_2 / max( || c ||_2, 1 ).
+    El::Matrix<Real> rDual;
+    El::Gemv( El::TRANSPOSE, Real(1), A, y, rDual );
+    El::Gemv( El::TRANSPOSE, Real(1), G, z, Real(1), rDual );
+    rDual += c;
+    const Real cFrob = El::FrobeniusNorm( c );
+    const Real rDualFrob = El::FrobeniusNorm( c );
+    const Real dualRelResid = rDualFrob / El::Max( cFrob, Real(1) );
+    El::Output
+    ("|| A^T y + G^T z + c ||_2 / max( || c ||_2, 1 ) = ",dualRelResid);
+}
+
+int main( int argc, char* argv[] )
+{
+    El::Environment env( argc, argv );
+
+    try
+    {
+        const El::Int m = El::Input("--m","height of A",100);
+        const El::Int n = El::Input("--n","width of A",100);
+        const El::Int k = El::Input("--k","height of G",100);
+        El::ProcessInput();
+
+        RandomFeasibleLP<float>( m, n, k );
+        RandomFeasibleLP<double>( m, n, k );
+#ifdef EL_HAVE_QD
+        RandomFeasibleLP<El::DoubleDouble>( m, n, k );
+        RandomFeasibleLP<El::QuadDouble>( m, n, k );
+#endif
+#ifdef EL_HAVE_QUAD
+        RandomFeasibleLP<El::Quad>( m, n, k );
+#endif
+#ifdef EL_HAVE_MPC
+        RandomFeasibleLP<El::BigFloat>( m, n, k );
+#endif
+    }
+    catch( std::exception& e ) { El::ReportException(e); }
+
+    return 0;
+}

--- a/examples/optimization/RandomFeasibleLP.cpp
+++ b/examples/optimization/RandomFeasibleLP.cpp
@@ -31,13 +31,18 @@ void RandomFeasibleLP( El::Int m, El::Int n, El::Int k )
   
     // Solve the primal/dual Linear Program with the default options
     El::Matrix<Real> x, y, z, s;
+    El::Timer timer;
+    timer.Start();
     El::LP( A, G, b, c, h, x, y, z, s );
+    El::Output("Primal-dual LP took ",timer.Stop()," seconds");
   
     // Print the primal and dual objective values
     const Real primal = El::Dot(c,x);
     const Real dual = -El::Dot(b,y) - El::Dot(h,z);
+    const Real relGap = El::Abs(primal-dual) / El::Max(El::Abs(dual),Real(1));
     El::Output("c^T x = ",primal);
     El::Output("-b^T y - h^T z = ",dual);
+    El::Output("|gap| / max( |dual|, 1 ) = ",relGap);
   
     // Print the relative primal feasibility residual,
     //   || A x - b ||_2 / max( || b ||_2, 1 ).
@@ -56,10 +61,11 @@ void RandomFeasibleLP( El::Int m, El::Int n, El::Int k )
     El::Gemv( El::TRANSPOSE, Real(1), G, z, Real(1), rDual );
     rDual += c;
     const Real cFrob = El::FrobeniusNorm( c );
-    const Real rDualFrob = El::FrobeniusNorm( c );
+    const Real rDualFrob = El::FrobeniusNorm( rDual );
     const Real dualRelResid = rDualFrob / El::Max( cFrob, Real(1) );
     El::Output
     ("|| A^T y + G^T z + c ||_2 / max( || c ||_2, 1 ) = ",dualRelResid);
+    El::Output("");
 }
 
 int main( int argc, char* argv[] )
@@ -68,9 +74,9 @@ int main( int argc, char* argv[] )
 
     try
     {
-        const El::Int m = El::Input("--m","height of A",100);
-        const El::Int n = El::Input("--n","width of A",100);
-        const El::Int k = El::Input("--k","height of G",100);
+        const El::Int m = El::Input("--m","height of A",70);
+        const El::Int n = El::Input("--n","width of A",80);
+        const El::Int k = El::Input("--k","height of G",90);
         El::ProcessInput();
 
         RandomFeasibleLP<float>( m, n, k );

--- a/src/lapack_like/equilibrate/SymmetricRuizEquil.cpp
+++ b/src/lapack_like/equilibrate/SymmetricRuizEquil.cpp
@@ -2,8 +2,8 @@
    Copyright (c) 2009-2016, Jack Poulson
    All rights reserved.
 
-   This file is part of Elemental and is under the BSD 2-Clause License, 
-   which can be found in the LICENSE file in the root directory, or at 
+   This file is part of Elemental and is under the BSD 2-Clause License,
+   which can be found in the LICENSE file in the root directory, or at
    http://opensource.org/licenses/BSD-2-Clause
 */
 #include <El.hpp>
@@ -16,7 +16,7 @@ inline Real DampScaling( Real alpha )
     static const Real tol = Pow(limits::Epsilon<Real>(),Real(0.33));
     if( alpha == Real(0) )
         return 1;
-    else 
+    else
         return Max(alpha,tol);
 }
 
@@ -28,17 +28,35 @@ inline Real SquareRootScaling( Real alpha )
 
 template<typename F>
 void SymmetricRuizEquil
-( Matrix<F>& A, 
-  Matrix<Base<F>>& d, 
+( Matrix<F>& A,
+  Matrix<Base<F>>& d,
   Int maxIter, bool progress )
 {
     DEBUG_CSE
-    LogicError("This routine is not yet written");
+    typedef Base<F> Real;
+    const Int n = A.Height();
+    Ones( d, n, 1 );
+
+    Matrix<Real> scales;
+    const Int indent = PushIndent();
+    for( Int iter=0; iter<maxIter; ++iter )
+    {
+        // Rescale the columns (and rows)
+        // ------------------------------
+        ColumnMaxNorms( A, scales );
+        EntrywiseMap( scales, function<Real(Real)>(DampScaling<Real>) );
+        EntrywiseMap( scales, function<Real(Real)>(SquareRootScaling<Real>) );
+        DiagonalScale( LEFT, NORMAL, scales, d );
+        // TODO(poulson): Replace with SymmetricDiagonalSolve
+        DiagonalSolve( RIGHT, NORMAL, scales, A );
+        DiagonalSolve( LEFT, NORMAL, scales, A );
+    }
+    SetIndent( indent );
 }
 
 template<typename F>
 void SymmetricRuizEquil
-( ElementalMatrix<F>& APre, 
+( ElementalMatrix<F>& APre,
   ElementalMatrix<Base<F>>& dPre,
   Int maxIter, bool progress )
 {
@@ -69,7 +87,7 @@ void SymmetricRuizEquil
         EntrywiseMap( scales, function<Real(Real)>(DampScaling<Real>) );
         EntrywiseMap( scales, function<Real(Real)>(SquareRootScaling<Real>) );
         DiagonalScale( LEFT, NORMAL, scales, d );
-        // TODO: Replace with SymmetricDiagonalSolve
+        // TODO(poulson): Replace with SymmetricDiagonalSolve
         DiagonalSolve( RIGHT, NORMAL, scales, A );
         DiagonalSolve( LEFT, NORMAL, scales, A );
     }
@@ -78,7 +96,7 @@ void SymmetricRuizEquil
 
 template<typename F>
 void SymmetricRuizEquil
-( SparseMatrix<F>& A, 
+( SparseMatrix<F>& A,
   Matrix<Base<F>>& d,
   Int maxIter, bool progress )
 {
@@ -104,8 +122,8 @@ void SymmetricRuizEquil
 
 template<typename F>
 void SymmetricRuizEquil
-( DistSparseMatrix<F>& A, 
-  DistMultiVec<Base<F>>& d, 
+( DistSparseMatrix<F>& A,
+  DistMultiVec<Base<F>>& d,
   Int maxIter, bool progress )
 {
     DEBUG_CSE


### PR DESCRIPTION
The sequential dense LPs were non-functioning due to the sequential dense equilibration routines not having been implemented (despite the *distributed* dense implementations existing for some time, as well as the sequential and distributed sparse implementations).