### PR TITLE
Conda recipe for Linux

### DIFF
--- a/conda/build.sh
+++ b/conda/build.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+
+NPROC=`nproc`
+
+git checkout tags/v0.87.5
+
+mkdir build
+
+cd build
+
+cmake \
+-DCMAKE_INSTALL_PREFIX="${PREFIX}" \
+-DCMAKE_CXX_COMPILER="${PREFIX}/bin/g++" \
+-DCMAKE_C_COMPILER="${PREFIX}/bin/gcc" \
+-DCMAKE_Fortran_COMPILER="${PREFIX}/bin/gfortran" \
+-DEL_USE_64BIT_INTS=ON \
+-DEL_HAVE_QUADMATH=OFF \
+-DCMAKE_BUILD_TYPE=Release \
+-DEL_HYBRID=ON \
+-DBUILD_SHARED_LIBS=ON \
+-DMATH_LIBS="-L${PREFIX}/lib -lopenblas -lm" \
+-DINSTALL_PYTHON_PACKAGE=ON \
+-DEL_BUILD_METIS=ON \
+-DEL_DISABLE_VALGRIND=ON \
+-DEL_DISABLE_PARMETIS=ON \
+-DEL_HAVE_MPC=OFF \
+.. 
+
+
+make -j $NPROC
+
+make install

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -1,0 +1,37 @@
+package:
+  name: libelemental
+  version: "0.87.5"
+
+source:
+  git_url: https://github.com/elemental/Elemental.git
+
+build:
+  features:
+    - xdata
+
+  rpaths:
+    - lib/
+    - lib64/
+
+requirements:
+  build:
+    - gcc >=4.8.5
+    - python >=2.7,<3
+    - openblas
+    - mpich2
+    - git
+    - cmake >=2.8
+  
+  run:
+    - libgcc	
+    - python >=2.7,<3
+    - openblas
+    - mpich2
+    - numpy
+    - matplotlib
+    - networkx
+
+about:
+  home: http://libelemental.org
+  license: New BSD license
+  summary: 'C++ library for distributed memory linear algebra and optimization'

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -6,9 +6,6 @@ source:
   git_url: https://github.com/elemental/Elemental.git
 
 build:
-  features:
-    - xdata
-
   rpaths:
     - lib/
     - lib64/


### PR DESCRIPTION
The intention is to combine this Linux recipe for libelemental with the OS X recipe in https://github.com/elemental/Elemental/pull/151

Updated/made a few modifications to the 0.86.xx one (most notably the addition of lib64/ for finding the libs; previously only lib/ was needed there). This snapshot seems to work nicely with our libskylark, but surely it could be made more generic and improved after being combined with  the OS X conda recipe.

Some notes:

- Building the recipe (builds OK with few warnings in my machine):
```[gkollias@dccxl001 Elemental]$ conda build conda```

- Putting the resulting tarball in a dir - will play the role of "local" conda channel (alternatively upload e.g. to an Anaconda repository):
```cp /u/gkollias/anaconda2/conda-bld/linux-64/libelemental-0.87.5-0.tar.bz2 /u/gkollias/conda/channel/linux-64/```

- Indexing the channel:
```conda index /u/gkollias/conda/channel/linux-64/```

- Installing libelemental (to be used with an Anaconda installation):
```conda install libelemental=0.87.5 --channel file:///u/gkollias/conda/channel```

- Using libelemental's python bindings (the following just works!):
```In [1]: import El; A = El.Matrix(); El.Uniform(A, 100, 100); triplet = El.SVD(A);```
