### PR TITLE
Replacing hardcoded 'lib' by the CMAKE variable in ElVars file

### DIFF
--- a/cmake/configure_files/ElVars.in
+++ b/cmake/configure_files/ElVars.in
@@ -1,7 +1,7 @@
 # To help simplify including Elemental in external projects
 
 EL_INC = @CMAKE_INSTALL_PREFIX@/include
-EL_LIB = @CMAKE_INSTALL_PREFIX@/lib
+EL_LIB = @CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_LIBDIR@
 
 CC = @CMAKE_C_COMPILER@
 CXX = @CMAKE_CXX_COMPILER@


### PR DESCRIPTION
Now linking works when system uses 'lib64' or other variants