### PR TITLE
Support block matrices in several BLAS1 routines

### DIFF
--- a/include/El/blas_like/level1/Dot.hpp
+++ b/include/El/blas_like/level1/Dot.hpp
@@ -19,7 +19,7 @@ T Dot( const Matrix<T>& A, const Matrix<T>& B )
 }
 
 template<typename T>
-T Dot( const ElementalMatrix<T>& A, const ElementalMatrix<T>& B )
+T Dot( const AbstractDistMatrix<T>& A, const AbstractDistMatrix<T>& B )
 {
     EL_DEBUG_CSE
     return HilbertSchmidt( A, B );
@@ -114,7 +114,7 @@ T Dotu( const DistMultiVec<T>& A, const DistMultiVec<T>& B )
   EL_EXTERN template T Dot \
   ( const Matrix<T>& A, const Matrix<T>& B ); \
   EL_EXTERN template T Dot \
-  ( const ElementalMatrix<T>& A, const ElementalMatrix<T>& B ); \
+  ( const AbstractDistMatrix<T>& A, const AbstractDistMatrix<T>& B ); \
   EL_EXTERN template T Dot \
   ( const DistMultiVec<T>& A, const DistMultiVec<T>& B ); \
   EL_EXTERN template T Dotu \

--- a/include/El/blas_like/level1/Hadamard.hpp
+++ b/include/El/blas_like/level1/Hadamard.hpp
@@ -42,9 +42,9 @@ void Hadamard( const Matrix<T>& A, const Matrix<T>& B, Matrix<T>& C )
 
 template<typename T>
 void Hadamard
-( const ElementalMatrix<T>& A,
-  const ElementalMatrix<T>& B,
-        ElementalMatrix<T>& C )
+( const AbstractDistMatrix<T>& A,
+  const AbstractDistMatrix<T>& B,
+        AbstractDistMatrix<T>& C )
 {
     EL_DEBUG_CSE
     const DistData& ADistData = A.DistData();
@@ -87,9 +87,9 @@ void Hadamard
   EL_EXTERN template void Hadamard \
   ( const Matrix<T>& A, const Matrix<T>& B, Matrix<T>& C ); \
   EL_EXTERN template void Hadamard \
-  ( const ElementalMatrix<T>& A, \
-    const ElementalMatrix<T>& B, \
-          ElementalMatrix<T>& C ); \
+  ( const AbstractDistMatrix<T>& A, \
+    const AbstractDistMatrix<T>& B, \
+          AbstractDistMatrix<T>& C ); \
   EL_EXTERN template void Hadamard \
   ( const DistMultiVec<T>& A, \
     const DistMultiVec<T>& B, \

--- a/include/El/blas_like/level1/Hadamard.hpp
+++ b/include/El/blas_like/level1/Hadamard.hpp
@@ -60,6 +60,9 @@ void Hadamard
         LogicError("A, B, and C must share the same distribution");
     if( A.ColAlign() != B.ColAlign() || A.RowAlign() != B.RowAlign() )
         LogicError("A and B must be aligned");
+    if ( A.BlockHeight() != B.BlockHeight() ||
+         A.BlockWidth() != B.BlockWidth())
+      LogicError("A and B must have the same block size");
     C.AlignWith( A.DistData() );
     C.Resize( A.Height(), A.Width() );
     Hadamard( A.LockedMatrix(), B.LockedMatrix(), C.Matrix() );

--- a/include/El/blas_like/level1/decl.hpp
+++ b/include/El/blas_like/level1/decl.hpp
@@ -196,9 +196,9 @@ void Recv( Matrix<T>& A, mpi::Comm comm, int source );
 template<typename Field>
 void ColumnTwoNorms
 ( const Matrix<Field>& X, Matrix<Base<Field>>& norms );
-template<typename Field,Dist U,Dist V>
+template<typename Field,Dist U,Dist V,DistWrap W>
 void ColumnTwoNorms
-( const DistMatrix<Field,U,V>& X, DistMatrix<Base<Field>,V,STAR>& norms );
+( const DistMatrix<Field,U,V,W>& X, DistMatrix<Base<Field>,V,STAR,W>& norms );
 template<typename Field>
 void ColumnTwoNorms
 ( const DistMultiVec<Field>& X, Matrix<Base<Field>>& norms );
@@ -235,9 +235,9 @@ void ColumnTwoNorms
 template<typename Ring>
 void ColumnMaxNorms
 ( const Matrix<Ring>& X, Matrix<Base<Ring>>& norms );
-template<typename Ring,Dist U,Dist V>
+template<typename Ring,Dist U,Dist V,DistWrap W>
 void ColumnMaxNorms
-( const DistMatrix<Ring,U,V>& X, DistMatrix<Base<Ring>,V,STAR>& norms );
+( const DistMatrix<Ring,U,V,W>& X, DistMatrix<Base<Ring>,V,STAR,W>& norms );
 template<typename Ring>
 void ColumnMaxNorms
 ( const DistMultiVec<Ring>& X, Matrix<Base<Ring>>& norms );
@@ -802,7 +802,7 @@ void DiagonalSolve
 template<typename T>
 T Dot( const Matrix<T>& A, const Matrix<T>& B );
 template<typename T>
-T Dot( const ElementalMatrix<T>& A, const ElementalMatrix<T>& B );
+T Dot( const AbstractDistMatrix<T>& A, const AbstractDistMatrix<T>& B );
 template<typename T>
 T Dot( const DistMultiVec<T>& A, const DistMultiVec<T>& B );
 
@@ -1155,9 +1155,9 @@ template<typename T>
 void Hadamard( const Matrix<T>& A, const Matrix<T>& B, Matrix<T>& C );
 template<typename T>
 void Hadamard
-( const ElementalMatrix<T>& A,
-  const ElementalMatrix<T>& B,
-        ElementalMatrix<T>& C );
+( const AbstractDistMatrix<T>& A,
+  const AbstractDistMatrix<T>& B,
+        AbstractDistMatrix<T>& C );
 template<typename T>
 void Hadamard
 ( const DistMultiVec<T>& A,
@@ -1170,7 +1170,7 @@ template<typename T>
 T HilbertSchmidt( const Matrix<T>& A, const Matrix<T>& B );
 template<typename T>
 T HilbertSchmidt
-( const ElementalMatrix<T>& A, const ElementalMatrix<T>& C );
+( const AbstractDistMatrix<T>& A, const AbstractDistMatrix<T>& C );
 template<typename T>
 T HilbertSchmidt( const DistMultiVec<T>& A, const DistMultiVec<T>& B );
 

--- a/src/blas_like/level1/ColumnNorms.cpp
+++ b/src/blas_like/level1/ColumnNorms.cpp
@@ -103,9 +103,9 @@ void ColumnMaxNorms( const Matrix<Field>& X, Matrix<Base<Field>>& norms )
     }
 }
 
-template<typename Field,Dist U,Dist V>
+template<typename Field,Dist U,Dist V,DistWrap W>
 void ColumnTwoNorms
-( const DistMatrix<Field,U,V>& A, DistMatrix<Base<Field>,V,STAR>& norms )
+( const DistMatrix<Field,U,V,W>& A, DistMatrix<Base<Field>,V,STAR,W>& norms )
 {
     EL_DEBUG_CSE
     norms.AlignWith( A );
@@ -118,9 +118,9 @@ void ColumnTwoNorms
     ColumnTwoNormsHelper( A.LockedMatrix(), norms.Matrix(), A.ColComm() );
 }
 
-template<typename Field,Dist U,Dist V>
+template<typename Field,Dist U,Dist V,DistWrap W>
 void ColumnMaxNorms
-( const DistMatrix<Field,U,V>& A, DistMatrix<Base<Field>,V,STAR>& norms )
+( const DistMatrix<Field,U,V,W>& A, DistMatrix<Base<Field>,V,STAR,W>& norms )
 {
     EL_DEBUG_CSE
     norms.AlignWith( A );
@@ -363,11 +363,17 @@ void ColumnTwoNorms
 
 #define PROTO_DIST(Field,U,V) \
   template void ColumnTwoNorms \
-  ( const DistMatrix<Field,U,V>& X, \
-          DistMatrix<Base<Field>,V,STAR>& norms ); \
+  ( const DistMatrix<Field,U,V,ELEMENT>& X, \
+          DistMatrix<Base<Field>,V,STAR,ELEMENT>& norms ); \
   template void ColumnMaxNorms \
-  ( const DistMatrix<Field,U,V>& X, \
-          DistMatrix<Base<Field>,V,STAR>& norms );
+  ( const DistMatrix<Field,U,V,ELEMENT>& X, \
+          DistMatrix<Base<Field>,V,STAR,ELEMENT>& norms ); \
+  template void ColumnTwoNorms \
+  ( const DistMatrix<Field,U,V,BLOCK>& X, \
+          DistMatrix<Base<Field>,V,STAR,BLOCK>& norms ); \
+  template void ColumnMaxNorms \
+  ( const DistMatrix<Field,U,V,BLOCK>& X, \
+          DistMatrix<Base<Field>,V,STAR,BLOCK>& norms );
 
 #define PROTO(Field) \
   template void ColumnTwoNorms \

--- a/src/blas_like/level1/HilbertSchmidt.cpp
+++ b/src/blas_like/level1/HilbertSchmidt.cpp
@@ -53,6 +53,9 @@ Ring HilbertSchmidt
         LogicError("A and B must have the same distribution");
     if( A.ColAlign() != B.ColAlign() || A.RowAlign() != B.RowAlign() )
         LogicError("Matrices must be aligned");
+    if ( A.BlockHeight() != B.BlockHeight() ||
+         A.BlockWidth() != B.BlockWidth())
+      LogicError("A and B must have the same block size");
 
     Ring innerProd;
     if( A.Participating() )

--- a/src/blas_like/level1/HilbertSchmidt.cpp
+++ b/src/blas_like/level1/HilbertSchmidt.cpp
@@ -41,7 +41,7 @@ Ring HilbertSchmidt( const Matrix<Ring>& A, const Matrix<Ring>& B )
 
 template<typename Ring>
 Ring HilbertSchmidt
-( const ElementalMatrix<Ring>& A, const ElementalMatrix<Ring>& B )
+( const AbstractDistMatrix<Ring>& A, const AbstractDistMatrix<Ring>& B )
 {
     EL_DEBUG_CSE
     if( A.Height() != B.Height() || A.Width() != B.Width() )
@@ -112,7 +112,7 @@ Ring HilbertSchmidt( const DistMultiVec<Ring>& A, const DistMultiVec<Ring>& B )
   template Ring HilbertSchmidt \
   ( const Matrix<Ring>& A, const Matrix<Ring>& B ); \
   template Ring HilbertSchmidt \
-  ( const ElementalMatrix<Ring>& A, const ElementalMatrix<Ring>& B ); \
+  ( const AbstractDistMatrix<Ring>& A, const AbstractDistMatrix<Ring>& B ); \
   template Ring HilbertSchmidt \
   ( const DistMultiVec<Ring>& A, const DistMultiVec<Ring>& B );
 

--- a/tests/blas_like/ColumnNorms.cpp
+++ b/tests/blas_like/ColumnNorms.cpp
@@ -33,7 +33,10 @@ void TestColumnTwoNorms(Int m, Int n, const Grid& g, bool print)
     }
     expected = mpi::AllReduce(expected, g.ColComm());
     expected = Sqrt(expected);
-    if (Abs(got - expected) > 10 * limits::Epsilon<El::Base<T>>())
+    // Compute max(expected, 1) to use relative bound.
+    // (std::max and El::Max don't support BigFloat.
+    T div = expected > 1 ? expected : 1;
+    if (Abs(got - expected) / div > m * n * 10 * limits::Epsilon<El::Base<T>>())
     {
       Output("Results do not match, norms(", j, ")=", got,
              " instead of ", expected);
@@ -90,19 +93,17 @@ int main(int argc, char** argv)
     TestColumnTwoNorms<float, BLOCK>(m, n, g, print);
     TestColumnTwoNorms<double, ELEMENT>(m, n, g, print);
     TestColumnTwoNorms<double, BLOCK>(m, n, g, print);
-#if defined(EL_HAVE_QD) && defined(EL_ENABLE_DOUBLEDOUBLE)
+#if defined(EL_HAVE_QD)
     TestColumnTwoNorms<DoubleDouble, ELEMENT>(m, n, g, print);
     TestColumnTwoNorms<DoubleDouble, BLOCK>(m, n, g, print);
-#endif
-#if defined(EL_HAVE_QD) && defined(EL_ENABLE_QUADDOUBLE)
     TestColumnTwoNorms<QuadDouble, ELEMENT>(m, n, g, print);
     TestColumnTwoNorms<QuadDouble, BLOCK>(m, n, g, print);
 #endif
-#if defined(EL_HAVE_QUAD) && defined(EL_ENABLE_QUAD)
+#if defined(EL_HAVE_QUAD)
     TestColumnTwoNorms<Quad, ELEMENT>(m, n, g, print);
     TestColumnTwoNorms<Quad, BLOCK>(m, n, g, print);
 #endif
-#if defined(EL_HAVE_MPC) && defined(EL_ENABLE_BIGFLOAT)
+#if defined(EL_HAVE_MPC)
     TestColumnTwoNorms<BigFloat, ELEMENT>(m, n, g, print);
     TestColumnTwoNorms<BigFloat, BLOCK>(m, n, g, print);
 #endif
@@ -111,19 +112,17 @@ int main(int argc, char** argv)
     TestColumnMaxNorms<float, BLOCK>(m, n, g, print);
     TestColumnMaxNorms<double, ELEMENT>(m, n, g, print);
     TestColumnMaxNorms<double, BLOCK>(m, n, g, print);
-#if defined(EL_HAVE_QD) && defined(EL_ENABLE_DOUBLEDOUBLE)
+#if defined(EL_HAVE_QD)
     TestColumnMaxNorms<DoubleDouble, ELEMENT>(m, n, g, print);
     TestColumnMaxNorms<DoubleDouble, BLOCK>(m, n, g, print);
-#endif
-#if defined(EL_HAVE_QD) && defined(EL_ENABLE_QUADDOUBLE)
     TestColumnMaxNorms<QuadDouble, ELEMENT>(m, n, g, print);
     TestColumnMaxNorms<QuadDouble, BLOCK>(m, n, g, print);
 #endif
-#if defined(EL_HAVE_QUAD) && defined(EL_ENABLE_QUAD)
+#if defined(EL_HAVE_QUAD)
     TestColumnMaxNorms<Quad, ELEMENT>(m, n, g, print);
     TestColumnMaxNorms<Quad, BLOCK>(m, n, g, print);
 #endif
-#if defined(EL_HAVE_MPC) && defined(EL_ENABLE_BIGFLOAT)
+#if defined(EL_HAVE_MPC)
     TestColumnMaxNorms<BigFloat, ELEMENT>(m, n, g, print);
     TestColumnMaxNorms<BigFloat, BLOCK>(m, n, g, print);
 #endif

--- a/tests/blas_like/ColumnNorms.cpp
+++ b/tests/blas_like/ColumnNorms.cpp
@@ -1,0 +1,97 @@
+/*
+   Copyright (c) 2009-2016, Jack Poulson
+   All rights reserved.
+
+   This file is part of Elemental and is under the BSD 2-Clause License,
+   which can be found in the LICENSE file in the root directory, or at
+   http://opensource.org/licenses/BSD-2-Clause
+*/
+
+#include <El.hpp>
+using namespace El;
+
+template <typename T, DistWrap W>
+void TestColumnTwoNorms(Int m, Int n, const Grid& g, bool print) {
+  // Generate random matrix to test.
+  DistMatrix<T, MC, MR, W> A(g);
+  Uniform(A, m, n);
+  if (print) {
+    Print(A, "A");
+  }
+  DistMatrix<T, MR, STAR, W> norms(g);
+  ColumnTwoNorms(A, norms);
+  if (print) {
+    Print(norms, "norms");
+  }
+  for (Int j = 0; j < A.LocalWidth(); ++j) {
+    T got = norms.GetLocal(j, 0);
+    T expected = 0;
+    for (Int i = 0; i < A.LocalHeight(); ++i) {
+      T val = A.GetLocal(i, j);
+      expected += val * val;
+    }
+    expected = mpi::AllReduce(expected, g.ColComm());
+    expected = Sqrt(expected);
+    if (Abs(got - expected) > 1e-5) {
+      Output("Results do not match, norms(", j, ")=", got,
+             " instead of ", expected);
+      RuntimeError("got != expected");
+    }
+  }
+}
+
+template <typename T, DistWrap W>
+void TestColumnMaxNorms(Int m, Int n, const Grid& g, bool print) {
+  // Generate random matrix to test.
+  DistMatrix<T, MC, MR, W> A(g);
+  Uniform(A, m, n);
+  if (print) {
+    Print(A, "A");
+  }
+  DistMatrix<T, MR, STAR, W> norms(g);
+  ColumnMaxNorms(A, norms);
+  if (print) {
+    Print(norms, "norms");
+  }
+  for (Int j = 0; j < A.LocalWidth(); ++j) {
+    T got = norms.GetLocal(j, 0);
+    T expected = 0;
+    for (Int i = 0; i < A.LocalHeight(); ++i) {
+      expected = Max(expected, Abs(A.GetLocal(i, j)));
+    }
+    T r;
+    mpi::AllReduce(&expected, &r, 1, mpi::MAX, g.ColComm());
+    expected = r;
+    if (got != expected) {
+      Output("Results do not match, norms(", j, ")=", got,
+             " instead of ", expected);
+      RuntimeError("got != expected");
+    }
+  }
+}
+
+int main(int argc, char** argv) {
+  Environment env(argc, argv);
+  mpi::Comm comm = mpi::COMM_WORLD;
+  try {
+    const Int m = Input("--m", "height", 100);
+    const Int n = Input("--n", "width", 100);
+    const bool print = Input("--print", "print matrices?", false);
+    ProcessInput();
+    PrintInputReport();
+
+    const Grid g(comm);
+    OutputFromRoot(comm, "Testing ColumnTwoNorms");
+    TestColumnTwoNorms<float, ELEMENT>(m, n, g, print);
+    TestColumnTwoNorms<float, BLOCK>(m, n, g, print);
+    TestColumnTwoNorms<double, ELEMENT>(m, n, g, print);
+    TestColumnTwoNorms<double, BLOCK>(m, n, g, print);
+    OutputFromRoot(comm, "Testing ColumnMaxNorms");
+    TestColumnMaxNorms<float, ELEMENT>(m, n, g, print);
+    TestColumnMaxNorms<float, BLOCK>(m, n, g, print);
+    TestColumnMaxNorms<double, ELEMENT>(m, n, g, print);
+    TestColumnMaxNorms<double, BLOCK>(m, n, g, print);
+  } catch (exception& e) {
+    ReportException(e);
+  }
+}

--- a/tests/blas_like/Dot.cpp
+++ b/tests/blas_like/Dot.cpp
@@ -11,40 +11,44 @@
 using namespace El;
 
 template <typename T, DistWrap W>
-void TestDot(Int m, Int n, const Grid& g, bool print) {
+void TestDot(Int m, Int n, const Grid& g, bool print)
+{
   // Generate random matrices to test.
   DistMatrix<T, MC, MR, W> A(g);
   Uniform(A, m, n);
   DistMatrix<T, MC, MR, W> B(g);
   Uniform(B, m, n);
-  if (print) {
+  if (print)
+  {
     Print(A, "A");
     Print(B, "B");
   }
   // Do Dot.
   T got = Dot(A, B);
-  if (print) {
+  if (print)
     OutputFromRoot(g.Comm(), "result=", got);
-  }
   // Manually check results.
   T expected = 0;
-  for (Int j = 0; j < A.LocalWidth(); ++j) {
-    for (Int i = 0; i < B.LocalHeight(); ++i) {
-      expected += A.GetLocal(i, j) * B.GetLocal(i, j);
-    }
-  }
+  for (Int j = 0; j < A.LocalWidth(); ++j)
+    for (Int i = 0; i < B.LocalHeight(); ++i)
+      expected += Conj(A.GetLocal(i, j)) * B.GetLocal(i, j);
   expected = mpi::AllReduce(expected, g.Comm());
-  if (Abs(got - expected) > 1e-6) {
+  // The constant here is large because this is not an especially stable way
+  // to compute the dot product, but it provides a dumb implementation baseline.
+  if (Abs(got - expected) > 700 * limits::Epsilon<El::Base<T>>())
+  {
     Output("Results do not match, got=", got,
            " instead of ", expected);
     RuntimeError("got != expected");
   }
 }
 
-int main(int argc, char** argv) {
+int main(int argc, char** argv)
+{
   Environment env(argc, argv);
   mpi::Comm comm = mpi::COMM_WORLD;
-  try {
+  try
+  {
     const Int m = Input("--m", "height", 100);
     const Int n = Input("--n", "width", 100);
     const bool print = Input("--print", "print matrices?", false);
@@ -55,9 +59,39 @@ int main(int argc, char** argv) {
     OutputFromRoot(comm, "Testing Dot");
     TestDot<float, ELEMENT>(m, n, g, print);
     TestDot<float, BLOCK>(m, n, g, print);
+    TestDot<Complex<float>, ELEMENT>(m, n, g, print);
+    TestDot<Complex<float>, BLOCK>(m, n, g, print);
     TestDot<double, ELEMENT>(m, n, g, print);
     TestDot<double, BLOCK>(m, n, g, print);
-  } catch (exception& e) {
+    TestDot<Complex<double>, ELEMENT>(m, n, g, print);
+    TestDot<Complex<double>, BLOCK>(m, n, g, print);
+#if defined(EL_HAVE_QD) && defined(EL_ENABLE_DOUBLEDOUBLE)
+    TestDot<DoubleDouble, ELEMENT>(m, n, g, print);
+    TestDot<DoubleDouble, BLOCK>(m, n, g, print);
+    TestDot<Complex<DoubleDouble>, ELEMENT>(m, n, g, print);
+    TestDot<Complex<DoubleDouble>, BLOCK>(m, n, g, print);
+#endif
+#if defined(EL_HAVE_QD) && defined(EL_ENABLE_QUADDOUBLE)
+    TestDot<QuadDouble, ELEMENT>(m, n, g, print);
+    TestDot<QuadDouble, BLOCK>(m, n, g, print);
+    TestDot<Complex<QuadDouble>, ELEMENT>(m, n, g, print);
+    TestDot<Complex<QuadDouble>, BLOCK>(m, n, g, print);
+#endif
+#if defined(EL_HAVE_QUAD) && defined(EL_ENABLE_QUAD)
+    TestDot<Quad, ELEMENT>(m, n, g, print);
+    TestDot<Quad, BLOCK>(m, n, g, print);
+    TestDot<Complex<Quad>, ELEMENT>(m, n, g, print);
+    TestDot<Complex<Quad>, BLOCK>(m, n, g, print);
+#endif
+#if defined(EL_HAVE_MPC) && defined(EL_ENABLE_BIGFLOAT)
+    TestDot<BigFloat, ELEMENT>(m, n, g, print);
+    TestDot<BigFloat, BLOCK>(m, n, g, print);
+    TestDot<Complex<BigFloat>, ELEMENT>(m, n, g, print);
+    TestDot<Complex<BigFloat>, BLOCK>(m, n, g, print);
+#endif
+  }
+  catch (exception& e)
+  {
     ReportException(e);
   }
 }

--- a/tests/blas_like/Dot.cpp
+++ b/tests/blas_like/Dot.cpp
@@ -1,0 +1,63 @@
+/*
+   Copyright (c) 2009-2016, Jack Poulson
+   All rights reserved.
+
+   This file is part of Elemental and is under the BSD 2-Clause License,
+   which can be found in the LICENSE file in the root directory, or at
+   http://opensource.org/licenses/BSD-2-Clause
+*/
+
+#include <El.hpp>
+using namespace El;
+
+template <typename T, DistWrap W>
+void TestDot(Int m, Int n, const Grid& g, bool print) {
+  // Generate random matrices to test.
+  DistMatrix<T, MC, MR, W> A(g);
+  Uniform(A, m, n);
+  DistMatrix<T, MC, MR, W> B(g);
+  Uniform(B, m, n);
+  if (print) {
+    Print(A, "A");
+    Print(B, "B");
+  }
+  // Do Dot.
+  T got = Dot(A, B);
+  if (print) {
+    OutputFromRoot(g.Comm(), "result=", got);
+  }
+  // Manually check results.
+  T expected = 0;
+  for (Int j = 0; j < A.LocalWidth(); ++j) {
+    for (Int i = 0; i < B.LocalHeight(); ++i) {
+      expected += A.GetLocal(i, j) * B.GetLocal(i, j);
+    }
+  }
+  expected = mpi::AllReduce(expected, g.Comm());
+  if (Abs(got - expected) > 1e-6) {
+    Output("Results do not match, got=", got,
+           " instead of ", expected);
+    RuntimeError("got != expected");
+  }
+}
+
+int main(int argc, char** argv) {
+  Environment env(argc, argv);
+  mpi::Comm comm = mpi::COMM_WORLD;
+  try {
+    const Int m = Input("--m", "height", 100);
+    const Int n = Input("--n", "width", 100);
+    const bool print = Input("--print", "print matrices?", false);
+    ProcessInput();
+    PrintInputReport();
+
+    const Grid g(comm);
+    OutputFromRoot(comm, "Testing Dot");
+    TestDot<float, ELEMENT>(m, n, g, print);
+    TestDot<float, BLOCK>(m, n, g, print);
+    TestDot<double, ELEMENT>(m, n, g, print);
+    TestDot<double, BLOCK>(m, n, g, print);
+  } catch (exception& e) {
+    ReportException(e);
+  }
+}

--- a/tests/blas_like/Dot.cpp
+++ b/tests/blas_like/Dot.cpp
@@ -65,25 +65,23 @@ int main(int argc, char** argv)
     TestDot<double, BLOCK>(m, n, g, print);
     TestDot<Complex<double>, ELEMENT>(m, n, g, print);
     TestDot<Complex<double>, BLOCK>(m, n, g, print);
-#if defined(EL_HAVE_QD) && defined(EL_ENABLE_DOUBLEDOUBLE)
+#if defined(EL_HAVE_QD)
     TestDot<DoubleDouble, ELEMENT>(m, n, g, print);
     TestDot<DoubleDouble, BLOCK>(m, n, g, print);
     TestDot<Complex<DoubleDouble>, ELEMENT>(m, n, g, print);
     TestDot<Complex<DoubleDouble>, BLOCK>(m, n, g, print);
-#endif
-#if defined(EL_HAVE_QD) && defined(EL_ENABLE_QUADDOUBLE)
     TestDot<QuadDouble, ELEMENT>(m, n, g, print);
     TestDot<QuadDouble, BLOCK>(m, n, g, print);
     TestDot<Complex<QuadDouble>, ELEMENT>(m, n, g, print);
     TestDot<Complex<QuadDouble>, BLOCK>(m, n, g, print);
 #endif
-#if defined(EL_HAVE_QUAD) && defined(EL_ENABLE_QUAD)
+#if defined(EL_HAVE_QUAD)
     TestDot<Quad, ELEMENT>(m, n, g, print);
     TestDot<Quad, BLOCK>(m, n, g, print);
     TestDot<Complex<Quad>, ELEMENT>(m, n, g, print);
     TestDot<Complex<Quad>, BLOCK>(m, n, g, print);
 #endif
-#if defined(EL_HAVE_MPC) && defined(EL_ENABLE_BIGFLOAT)
+#if defined(EL_HAVE_MPC)
     TestDot<BigFloat, ELEMENT>(m, n, g, print);
     TestDot<BigFloat, BLOCK>(m, n, g, print);
     TestDot<Complex<BigFloat>, ELEMENT>(m, n, g, print);

--- a/tests/blas_like/Hadamard.cpp
+++ b/tests/blas_like/Hadamard.cpp
@@ -11,13 +11,15 @@
 using namespace El;
 
 template <typename T, DistWrap W>
-void TestHadamard(Int m, Int n, const Grid& g, bool print) {
+void TestHadamard(Int m, Int n, const Grid& g, bool print)
+{
   // Generate random matrices to test.
   DistMatrix<T, MC, MR, W> A(g);
   Uniform(A, m, n);
   DistMatrix<T, MC, MR, W> B(g);
   Uniform(B, m, n);
-  if (print) {
+  if (print)
+  {
     Print(A, "A");
     Print(B, "B");
   }
@@ -25,15 +27,17 @@ void TestHadamard(Int m, Int n, const Grid& g, bool print) {
   DistMatrix<T, MC, MR, W> C(g);
   Hadamard(A, B, C);
   mpi::Barrier(g.Comm());
-  if (print) {
+  if (print)
     Print(C, "C");
-  }
   // Manually check results.
-  for (Int j = 0; j < A.LocalWidth(); ++j) {
-    for (Int i = 0; i < A.LocalHeight(); ++i) {
+  for (Int j = 0; j < A.LocalWidth(); ++j) 
+  {
+    for (Int i = 0; i < A.LocalHeight(); ++i)
+    {
       T got = C.GetLocal(i, j);
       T expected = A.GetLocal(i, j) * B.GetLocal(i, j);
-      if (Abs(got - expected) > 1e-6) {
+      if (Abs(got - expected) > 10 * limits::Epsilon<El::Base<T>>())
+      {
         Output("Results do not match, C(", i, ",", j, ")=", got,
                " instead of ", expected);
         RuntimeError("got != expected");
@@ -42,10 +46,12 @@ void TestHadamard(Int m, Int n, const Grid& g, bool print) {
   }
 }
 
-int main(int argc, char** argv) {
+int main(int argc, char** argv)
+{
   Environment env(argc, argv);
   mpi::Comm comm = mpi::COMM_WORLD;
-  try {
+  try
+  {
     const Int m = Input("--m", "height", 100);
     const Int n = Input("--n", "width", 100);
     const bool print = Input("--print", "print matrices?", false);
@@ -56,9 +62,39 @@ int main(int argc, char** argv) {
     OutputFromRoot(comm, "Testing Hadamard");
     TestHadamard<float, ELEMENT>(m, n, g, print);
     TestHadamard<float, BLOCK>(m, n, g, print);
+    TestHadamard<Complex<float>, ELEMENT>(m, n, g, print);
+    TestHadamard<Complex<float>, BLOCK>(m, n, g, print);
     TestHadamard<double, ELEMENT>(m, n, g, print);
     TestHadamard<double, BLOCK>(m, n, g, print);
-  } catch (exception& e) {
+    TestHadamard<Complex<double>, ELEMENT>(m, n, g, print);
+    TestHadamard<Complex<double>, BLOCK>(m, n, g, print);
+#if defined(EL_HAVE_QD) && defined(EL_ENABLE_DOUBLEDOUBLE)
+    TestHadamard<DoubleDouble, ELEMENT>(m, n, g, print);
+    TestHadamard<DoubleDouble, BLOCK>(m, n, g, print);
+    TestHadamard<Complex<DoubleDouble>, ELEMENT>(m, n, g, print);
+    TestHadamard<Complex<DoubleDouble>, BLOCK>(m, n, g, print);
+#endif
+#if defined(EL_HAVE_QD) && defined(EL_ENABLE_QUADDOUBLE)
+    TestHadamard<QuadDouble, ELEMENT>(m, n, g, print);
+    TestHadamard<QuadDouble, BLOCK>(m, n, g, print);
+    TestHadamard<Complex<QuadDouble>, ELEMENT>(m, n, g, print);
+    TestHadamard<Complex<QuadDouble>, BLOCK>(m, n, g, print);
+#endif
+#if defined(EL_HAVE_QUAD) && defined(EL_ENABLE_QUAD)
+    TestHadamard<Quad, ELEMENT>(m, n, g, print);
+    TestHadamard<Quad, BLOCK>(m, n, g, print);
+    TestHadamard<Complex<Quad>, ELEMENT>(m, n, g, print);
+    TestHadamard<Complex<Quad>, BLOCK>(m, n, g, print);
+#endif
+#if defined(EL_HAVE_MPC) && defined(EL_ENABLE_BIGFLOAT)
+    TestHadamard<BigFloat, ELEMENT>(m, n, g, print);
+    TestHadamard<BigFloat, BLOCK>(m, n, g, print);
+    TestHadamard<Complex<BigFloat>, ELEMENT>(m, n, g, print);
+    TestHadamard<Complex<BigFloat>, BLOCK>(m, n, g, print);
+#endif
+  }
+  catch (exception& e)
+  {
     ReportException(e);
   }
 }

--- a/tests/blas_like/Hadamard.cpp
+++ b/tests/blas_like/Hadamard.cpp
@@ -68,25 +68,23 @@ int main(int argc, char** argv)
     TestHadamard<double, BLOCK>(m, n, g, print);
     TestHadamard<Complex<double>, ELEMENT>(m, n, g, print);
     TestHadamard<Complex<double>, BLOCK>(m, n, g, print);
-#if defined(EL_HAVE_QD) && defined(EL_ENABLE_DOUBLEDOUBLE)
+#if defined(EL_HAVE_QD)
     TestHadamard<DoubleDouble, ELEMENT>(m, n, g, print);
     TestHadamard<DoubleDouble, BLOCK>(m, n, g, print);
     TestHadamard<Complex<DoubleDouble>, ELEMENT>(m, n, g, print);
     TestHadamard<Complex<DoubleDouble>, BLOCK>(m, n, g, print);
-#endif
-#if defined(EL_HAVE_QD) && defined(EL_ENABLE_QUADDOUBLE)
     TestHadamard<QuadDouble, ELEMENT>(m, n, g, print);
     TestHadamard<QuadDouble, BLOCK>(m, n, g, print);
     TestHadamard<Complex<QuadDouble>, ELEMENT>(m, n, g, print);
     TestHadamard<Complex<QuadDouble>, BLOCK>(m, n, g, print);
 #endif
-#if defined(EL_HAVE_QUAD) && defined(EL_ENABLE_QUAD)
+#if defined(EL_HAVE_QUAD)
     TestHadamard<Quad, ELEMENT>(m, n, g, print);
     TestHadamard<Quad, BLOCK>(m, n, g, print);
     TestHadamard<Complex<Quad>, ELEMENT>(m, n, g, print);
     TestHadamard<Complex<Quad>, BLOCK>(m, n, g, print);
 #endif
-#if defined(EL_HAVE_MPC) && defined(EL_ENABLE_BIGFLOAT)
+#if defined(EL_HAVE_MPC)
     TestHadamard<BigFloat, ELEMENT>(m, n, g, print);
     TestHadamard<BigFloat, BLOCK>(m, n, g, print);
     TestHadamard<Complex<BigFloat>, ELEMENT>(m, n, g, print);

--- a/tests/blas_like/Hadamard.cpp
+++ b/tests/blas_like/Hadamard.cpp
@@ -1,0 +1,64 @@
+/*
+   Copyright (c) 2009-2016, Jack Poulson
+   All rights reserved.
+
+   This file is part of Elemental and is under the BSD 2-Clause License,
+   which can be found in the LICENSE file in the root directory, or at
+   http://opensource.org/licenses/BSD-2-Clause
+*/
+
+#include <El.hpp>
+using namespace El;
+
+template <typename T, DistWrap W>
+void TestHadamard(Int m, Int n, const Grid& g, bool print) {
+  // Generate random matrices to test.
+  DistMatrix<T, MC, MR, W> A(g);
+  Uniform(A, m, n);
+  DistMatrix<T, MC, MR, W> B(g);
+  Uniform(B, m, n);
+  if (print) {
+    Print(A, "A");
+    Print(B, "B");
+  }
+  // Apply Hadamard.
+  DistMatrix<T, MC, MR, W> C(g);
+  Hadamard(A, B, C);
+  mpi::Barrier(g.Comm());
+  if (print) {
+    Print(C, "C");
+  }
+  // Manually check results.
+  for (Int j = 0; j < A.LocalWidth(); ++j) {
+    for (Int i = 0; i < A.LocalHeight(); ++i) {
+      T got = C.GetLocal(i, j);
+      T expected = A.GetLocal(i, j) * B.GetLocal(i, j);
+      if (Abs(got - expected) > 1e-6) {
+        Output("Results do not match, C(", i, ",", j, ")=", got,
+               " instead of ", expected);
+        RuntimeError("got != expected");
+      }
+    }
+  }
+}
+
+int main(int argc, char** argv) {
+  Environment env(argc, argv);
+  mpi::Comm comm = mpi::COMM_WORLD;
+  try {
+    const Int m = Input("--m", "height", 100);
+    const Int n = Input("--n", "width", 100);
+    const bool print = Input("--print", "print matrices?", false);
+    ProcessInput();
+    PrintInputReport();
+
+    const Grid g(comm);
+    OutputFromRoot(comm, "Testing Hadamard");
+    TestHadamard<float, ELEMENT>(m, n, g, print);
+    TestHadamard<float, BLOCK>(m, n, g, print);
+    TestHadamard<double, ELEMENT>(m, n, g, print);
+    TestHadamard<double, BLOCK>(m, n, g, print);
+  } catch (exception& e) {
+    ReportException(e);
+  }
+}


### PR DESCRIPTION
This adds support for block matrices in the `Hadamard`, `Dot`, `HilbertSchmidt`, `ColumnTwoNorms`, and `ColumnMaxNorms` functions (see #224). I also added tests for `Hadamard`, `Dot`, `ColumnTwoNorms`, and `ColumnMaxNorms`.

Let me know if any additional changes are needed.