### PR TITLE
Optimizing BLAS1-like routines

### DIFF
--- a/include/El/blas_like/level1/Copy.hpp
+++ b/include/El/blas_like/level1/Copy.hpp
@@ -22,10 +22,23 @@ void Copy( const Matrix<T>& A, Matrix<T>& B )
     const Int height = A.Height();
     const Int width = A.Width();
     B.Resize( height, width );
+    const Int ldA = A.LDim();
+    const Int ldB = B.LDim();
+    const T* ABuf = A.LockedBuffer();
+          T* BBuf = B.Buffer();
 
-    lapack::Copy
-    ( 'F', A.Height(), A.Width(),
-      A.LockedBuffer(), A.LDim(), B.Buffer(), B.LDim() );
+    // Copy all entries if memory is contiguous. Otherwise copy each
+    // column.
+    if( ldA == height && ldB == height ) {
+        MemCopy( BBuf, ABuf, height*width );
+    }
+    else {
+        EL_PARALLEL_FOR
+        for( Int j=0; j<width; ++j ) {
+            MemCopy(&BBuf[j*ldB], &ABuf[j*ldA], height);
+        }
+    }
+
 }
 
 template<typename S,typename T,

--- a/include/El/blas_like/level1/EntrywiseMap.hpp
+++ b/include/El/blas_like/level1/EntrywiseMap.hpp
@@ -19,13 +19,27 @@ void EntrywiseMap( Matrix<T>& A, function<T(const T&)> func )
     const Int n = A.Width();
     T* ABuf = A.Buffer();
     const Int ALDim = A.LDim();
-    EL_PARALLEL_FOR
-    for( Int j=0; j<n; ++j )
+
+    // Iterate over single loop if memory is contiguous. Otherwise
+    // iterate over double loop.
+    if( ALDim == m )
     {
-        EL_SIMD
-        for( Int i=0; i<m; ++i )
+        EL_PARALLEL_FOR
+        for( Int i=0; i<m*n; ++i )
         {
-            ABuf[i+j*ALDim] = func(ABuf[i+j*ALDim]);
+            ABuf[i] = func(ABuf[i]);
+        }
+    }
+    else
+    {
+        EL_PARALLEL_FOR
+        for( Int j=0; j<n; ++j )
+        {
+            EL_SIMD
+            for( Int i=0; i<m; ++i )
+            {
+                ABuf[i+j*ALDim] = func(ABuf[i+j*ALDim]);
+            }
         }
     }
 }

--- a/include/El/blas_like/level1/Fill.hpp
+++ b/include/El/blas_like/level1/Fill.hpp
@@ -61,7 +61,6 @@ void Fill( SparseMatrix<T>& A, T alpha )
     EL_DEBUG_CSE
     const Int m = A.Height();
     const Int n = A.Width();
-    A.Resize( m, n );
     Zero( A );
     if( alpha != T(0) )
     {
@@ -79,7 +78,6 @@ void Fill( DistSparseMatrix<T>& A, T alpha )
     EL_DEBUG_CSE
     const Int m = A.Height();
     const Int n = A.Width();
-    A.Resize( m, n );
     Zero( A );
     if( alpha != T(0) )
     {

--- a/include/El/blas_like/level1/Fill.hpp
+++ b/include/El/blas_like/level1/Fill.hpp
@@ -19,13 +19,24 @@ void Fill( Matrix<T>& A, T alpha )
     const Int n = A.Width();
     T* ABuf = A.Buffer();
     const Int ALDim = A.LDim();
-    EL_PARALLEL_FOR
-    for( Int j=0; j<n; ++j )
+
+    // Iterate over single loop if memory is contiguous. Otherwise
+    // iterate over double loop.
+    if( ALDim == m )
     {
-        EL_SIMD
-        for( Int i=0; i<m; ++i )
+        for( Int i=0; i<m*n; ++i )
         {
-            ABuf[i+j*ALDim] = alpha;
+            ABuf[i] = alpha;
+        }
+    }
+    else
+    {
+        for( Int j=0; j<n; ++j )
+        {
+            for( Int i=0; i<m; ++i )
+            {
+                ABuf[i+j*ALDim] = alpha;
+            }
         }
     }
 }

--- a/include/El/blas_like/level1/FillDiagonal.hpp
+++ b/include/El/blas_like/level1/FillDiagonal.hpp
@@ -17,7 +17,6 @@ void FillDiagonal( Matrix<T>& A, T alpha, Int offset )
     EL_DEBUG_CSE
     const Int height = A.Height();
     const Int width = A.Width();
-    EL_PARALLEL_FOR
     for( Int j=0; j<width; ++j )
     {
         const Int i = j-offset;

--- a/include/El/blas_like/level1/Hadamard.hpp
+++ b/include/El/blas_like/level1/Hadamard.hpp
@@ -29,14 +29,43 @@ void Hadamard( const Matrix<T>& A, const Matrix<T>& B, Matrix<T>& C )
     const Int ALDim = A.LDim();
     const Int BLDim = B.LDim();
     const Int CLDim = C.LDim();
-    EL_PARALLEL_FOR
-    for( Int j=0; j<width; ++j )
+
+    // Iterate over single loop if memory is contiguous. Otherwise
+    // iterate over double loop.
+    if( ALDim == height && BLDim == height && CLDim == height )
     {
-        EL_SIMD
-        for( Int i=0; i<height; ++i )
-          {
-              CBuf[i+j*CLDim] = ABuf[i+j*ALDim] * BBuf[i+j*BLDim];
-          }
+        // Check if output matrix is equal to either input matrix
+        if( CBuf == BBuf )
+        {
+            for( Int i=0; i<height*width; ++i )
+            {
+                CBuf[i] *= ABuf[i];
+            }
+        }
+        else if( CBuf == ABuf )
+        {
+            for( Int i=0; i<height*width; ++i )
+            {
+                CBuf[i] *= BBuf[i];
+            }
+        }
+        else
+        {
+            for( Int i=0; i<height*width; ++i )
+            {
+                CBuf[i] = ABuf[i] * BBuf[i];
+            }
+        }
+    }
+    else
+    {
+        for( Int j=0; j<width; ++j )
+        {
+            for( Int i=0; i<height; ++i )
+            {
+                CBuf[i+j*CLDim] = ABuf[i+j*ALDim] * BBuf[i+j*BLDim];
+            }
+        }
     }
 }
 

--- a/include/El/blas_like/level1/IndexDependentFill.hpp
+++ b/include/El/blas_like/level1/IndexDependentFill.hpp
@@ -19,15 +19,30 @@ void IndexDependentFill( Matrix<T>& A, function<T(Int,Int)> func )
     const Int n = A.Width();
     T* ABuf = A.Buffer();
     const Int ALDim = A.LDim();
-    EL_PARALLEL_FOR
-    for( Int j=0; j<n; ++j )
+
+    // Use entry-wise parallelization for column vectors. Otherwise
+    // use column-wise parallelization.
+    if( n == 1 )
     {
-        EL_SIMD
+        EL_PARALLEL_FOR
         for( Int i=0; i<m; ++i )
         {
-            ABuf[i+j*ALDim] = func(i,j);
+            ABuf[i] = func(i,0);
         }
     }
+    else
+    {
+        EL_PARALLEL_FOR
+        for( Int j=0; j<n; ++j )
+        {
+            EL_SIMD
+            for( Int i=0; i<m; ++i )
+            {
+                ABuf[i+j*ALDim] = func(i,j);
+            }
+        }
+    }
+
 }
 
 template<typename T>
@@ -39,17 +54,34 @@ void IndexDependentFill
     const Int nLoc = A.LocalWidth();
     T* ALocBuf = A.Buffer();
     const Int ALocLDim = A.LDim();
-    EL_PARALLEL_FOR
-    for( Int jLoc=0; jLoc<nLoc; ++jLoc )
+
+    // Use entry-wise parallelization for column vectors. Otherwise
+    // use column-wise parallelization.
+    if( nLoc == 1 )
     {
-        EL_SIMD
+        EL_PARALLEL_FOR
         for( Int iLoc=0; iLoc<mLoc; ++iLoc )
         {
             const Int i = A.GlobalRow(iLoc);
-            const Int j = A.GlobalCol(jLoc);
-            ALocBuf[iLoc+jLoc*ALocLDim] = func(i,j);
+            const Int j = A.GlobalCol(0);
+            ALocBuf[iLoc] = func(i,j);
         }
     }
+    else
+    {
+        EL_PARALLEL_FOR
+        for( Int jLoc=0; jLoc<nLoc; ++jLoc )
+        {
+            EL_SIMD
+            for( Int iLoc=0; iLoc<mLoc; ++iLoc )
+            {
+                const Int i = A.GlobalRow(iLoc);
+                const Int j = A.GlobalCol(jLoc);
+                ALocBuf[iLoc+jLoc*ALocLDim] = func(i,j);
+            }
+        }
+    }
+
 }
 
 #ifdef EL_INSTANTIATE_BLAS_LEVEL1

--- a/include/El/blas_like/level1/IndexDependentMap.hpp
+++ b/include/El/blas_like/level1/IndexDependentMap.hpp
@@ -19,15 +19,30 @@ void IndexDependentMap( Matrix<T>& A, function<T(Int,Int,const T&)> func )
     const Int n = A.Width();
     T* ABuf = A.Buffer();
     const Int ALDim = A.LDim();
-    EL_PARALLEL_FOR
-    for( Int j=0; j<n; ++j )
+
+    // Use entry-wise parallelization for column vectors. Otherwise
+    // use column-wise parallelization.
+    if( n == 1 )
     {
-        EL_SIMD
+        EL_PARALLEL_FOR
         for( Int i=0; i<m; ++i )
         {
-            ABuf[i+j*ALDim] = func(i,j,ABuf[i+j*ALDim]);
+            ABuf[i] = func(i,0,ABuf[i]);
         }
     }
+    else
+    {
+        EL_PARALLEL_FOR
+        for( Int j=0; j<n; ++j )
+        {
+            EL_SIMD
+            for( Int i=0; i<m; ++i )
+            {
+                ABuf[i+j*ALDim] = func(i,j,ABuf[i+j*ALDim]);
+            }
+        }
+    }
+
 }
 
 template<typename T>
@@ -39,17 +54,34 @@ void IndexDependentMap
     const Int nLoc = A.LocalWidth();
     T* ALocBuf = A.Buffer();
     const Int ALocLDim = A.LDim();
-    EL_PARALLEL_FOR
-    for( Int jLoc=0; jLoc<nLoc; ++jLoc )
+
+    // Use entry-wise parallelization for column vectors. Otherwise
+    // use column-wise parallelization.
+    if( nLoc == 1 )
     {
-        EL_SIMD
+        EL_PARALLEL_FOR
         for( Int iLoc=0; iLoc<mLoc; ++iLoc )
         {
             const Int i = A.GlobalRow(iLoc);
-            const Int j = A.GlobalCol(jLoc);
-            ALocBuf[iLoc+jLoc*ALocLDim] = func(i,j,ALocBuf[iLoc+jLoc*ALocLDim]);
+            const Int j = A.GlobalCol(0);
+            ALocBuf[iLoc] = func(i,j,ALocBuf[iLoc]);
         }
     }
+    else
+    {
+        EL_PARALLEL_FOR
+        for( Int jLoc=0; jLoc<nLoc; ++jLoc )
+        {
+            EL_SIMD
+            for( Int iLoc=0; iLoc<mLoc; ++iLoc )
+            {
+                const Int i = A.GlobalRow(iLoc);
+                const Int j = A.GlobalCol(jLoc);
+                ALocBuf[iLoc+jLoc*ALocLDim] = func(i,j,ALocBuf[iLoc+jLoc*ALocLDim]);
+            }
+        }
+    }
+
 }
 
 template<typename S,typename T>
@@ -64,15 +96,30 @@ void IndexDependentMap
     T* BBuf = B.Buffer();
     const Int ALDim = A.LDim();
     const Int BLDim = B.LDim();
-    EL_PARALLEL_FOR
-    for( Int j=0; j<n; ++j )
+
+    // Use entry-wise parallelization for column vectors. Otherwise
+    // use column-wise parallelization.
+    if( n == 1 )
     {
-        EL_SIMD
+        EL_PARALLEL_FOR
         for( Int i=0; i<m; ++i )
         {
-            BBuf[i+j*BLDim] = func(i,j,ABuf[i+j*ALDim]);
+            BBuf[i] = func(i,0,ABuf[i]);
         }
     }
+    else
+    {
+        EL_PARALLEL_FOR
+        for( Int j=0; j<n; ++j )
+        {
+            EL_SIMD
+            for( Int i=0; i<m; ++i )
+            {
+                BBuf[i+j*BLDim] = func(i,j,ABuf[i+j*ALDim]);
+            }
+        }
+    }
+
 }
 
 template<typename S,typename T,Dist U,Dist V,DistWrap wrap>
@@ -90,17 +137,34 @@ void IndexDependentMap
     T* BLocBuf = B.Buffer();
     const Int ALocLDim = A.LDim();
     const Int BLocLDim = B.LDim();
-    EL_PARALLEL_FOR
-    for( Int jLoc=0; jLoc<nLoc; ++jLoc )
+
+    // Use entry-wise parallelization for column vectors. Otherwise
+    // use column-wise parallelization.
+    if( nLoc == 1 )
     {
-        EL_SIMD
+        EL_PARALLEL_FOR
         for( Int iLoc=0; iLoc<mLoc; ++iLoc )
         {
             const Int i = A.GlobalRow(iLoc);
-            const Int j = A.GlobalCol(jLoc);
-            BLocBuf[iLoc+jLoc*BLocLDim] = func(i,j,ALocBuf[iLoc+jLoc*ALocLDim]);
+            const Int j = A.GlobalCol(0);
+            BLocBuf[iLoc] = func(i,j,ALocBuf[iLoc]);
         }
     }
+    else
+    {
+        EL_PARALLEL_FOR
+        for( Int jLoc=0; jLoc<nLoc; ++jLoc )
+        {
+            EL_SIMD
+            for( Int iLoc=0; iLoc<mLoc; ++iLoc )
+            {
+                const Int i = A.GlobalRow(iLoc);
+                const Int j = A.GlobalCol(jLoc);
+                BLocBuf[iLoc+jLoc*BLocLDim] = func(i,j,ALocBuf[iLoc+jLoc*ALocLDim]);
+            }
+        }
+    }
+
 }
 
 template<typename S,typename T,Dist U,Dist V>

--- a/include/El/blas_like/level1/Round.hpp
+++ b/include/El/blas_like/level1/Round.hpp
@@ -17,19 +17,8 @@ template<typename T>
 void Round( Matrix<T>& A )
 {
     EL_DEBUG_CSE
-    const Int m = A.Height();
-    const Int n = A.Width();
-    T* ABuf = A.Buffer();
-    const Int ALDim = A.LDim();
-    EL_PARALLEL_FOR
-    for( Int j=0; j<n; ++j )
-    {
-        EL_SIMD
-        for( Int i=0; i<m; ++i )
-        {
-            ABuf[i+j*ALDim] = Round(ABuf[i+j*ALDim]);
-        }
-    }
+    auto round = []( const T& alpha ) { return Round(alpha); };
+    EntrywiseMap( A, MakeFunction(round) );
 }
 
 template<>

--- a/include/El/blas_like/level1/Scale.hpp
+++ b/include/El/blas_like/level1/Scale.hpp
@@ -17,30 +17,35 @@ void Scale( S alphaS, Matrix<T>& A )
     EL_DEBUG_CSE
     const T alpha = T(alphaS);
 
-    T* ABuf = A.Buffer();
     const Int ALDim = A.LDim();
     const Int height = A.Height();
     const Int width = A.Width();
+    T* ABuf = A.Buffer();
 
     // TODO(poulson): Use imatcopy if MKL or OpenBLAS is detected
 
     if( alpha == T(0) )
     {
-        for( Int j=0; j<width; ++j )
-            for( Int i=0; i<height; ++i )
-                ABuf[i+j*ALDim] = 0;
+        Zero( A );
     }
     else if( alpha != T(1) )
     {
-        if( height >= width )
+        if( ALDim == height )
         {
-            for( Int j=0; j<width; ++j )
-                blas::Scal( height, alpha, &ABuf[j*ALDim], 1 );
+            for( Int i=0; i<height*width; ++i )
+            {
+                ABuf[i] *= alpha;
+            }
         }
         else
         {
-            for( Int i=0; i<height; ++i )
-                blas::Scal( width, alpha, &ABuf[i], ALDim );
+            for( Int j=0; j<width; ++j )
+            {
+                for( Int i=0; i<height; ++i )
+                {
+                    ABuf[i+j*ALDim] *= alpha;
+                }
+            }
         }
     }
 }
@@ -57,32 +62,18 @@ void Scale( S alphaS, Matrix<Real>& AReal, Matrix<Real>& AImag )
     {
         if( alpha == C(0) )
         {
-            Scale( Real(0), AReal );
-            Scale( Real(0), AImag );
+            Zero( AReal );
+            Zero( AImag );
         }
         else
         {
             const Real alphaReal=alpha.real(), alphaImag=alpha.imag();
-            vector<Real> aRealCopy(m);
-            Real* ARealBuf = AReal.Buffer();
-            Real* AImagBuf = AImag.Buffer();
-            const Int ARealLDim = AReal.LDim();
-            const Int AImagLDim = AImag.LDim();
-            for( Int j=0; j<n; ++j )
-            {
-                for( Int i=0; i<m; ++i )
-                    aRealCopy[i] = ARealBuf[i+j*ARealLDim];
-
-                blas::Scal( m, alphaReal, &ARealBuf[j*ARealLDim], 1 );
-                blas::Axpy
-                ( m, -alphaImag, &AImagBuf[j*AImagLDim], 1,
-                                 &ARealBuf[j*ARealLDim], 1 );
-
-                blas::Scal( m, alphaReal, &AImagBuf[j*AImagLDim], 1 );
-                blas::Axpy
-                ( m,  alphaImag, aRealCopy.data(),       1,
-                                 &AImagBuf[j*AImagLDim], 1 );
-            }
+            Matrix<Real> ARealCopy;
+            Copy( AReal, ARealCopy );
+            Scale( alphaReal, AReal );
+            Axpy( -alphaImag, AImag, AReal );
+            Scale( alphaReal, AImag );
+            Axpy( alphaImag, ARealCopy, AImag );
         }
     }
 }
@@ -150,6 +141,33 @@ void Scale( S alpha, DistMultiVec<T>& A )
     EL_DEBUG_CSE
     Scale( alpha, A.Matrix() );
 }
+
+#ifdef EL_INSTANTIATE_BLAS_LEVEL1
+# define EL_EXTERN
+#else
+# define EL_EXTERN extern
+#endif
+
+#define PROTO(T) \
+  EL_EXTERN template void Scale \
+  ( T alpha, Matrix<T>& A ); \
+  EL_EXTERN template void Scale \
+  ( T alpha, AbstractDistMatrix<T>& A ); \
+  EL_EXTERN template void Scale \
+  ( T alpha, SparseMatrix<T>& A ); \
+  EL_EXTERN template void Scale \
+  ( T alpha, DistSparseMatrix<T>& A ); \
+  EL_EXTERN template void Scale \
+  ( T alpha, DistMultiVec<T>& A );
+
+#define EL_ENABLE_DOUBLEDOUBLE
+#define EL_ENABLE_QUADDOUBLE
+#define EL_ENABLE_QUAD
+#define EL_ENABLE_BIGINT
+#define EL_ENABLE_BIGFLOAT
+#include <El/macros/Instantiate.h>
+
+#undef EL_EXTERN
 
 } // namespace El
 

--- a/include/El/blas_like/level1/ScaleTrapezoid.hpp
+++ b/include/El/blas_like/level1/ScaleTrapezoid.hpp
@@ -25,7 +25,6 @@ void ScaleTrapezoid( S alphaS, UpperOrLower uplo, Matrix<T>& A, Int offset )
 
     if( uplo == UPPER )
     {
-        EL_PARALLEL_FOR
         for( Int j=Max(0,offset-1); j<width; ++j )
         {
             const Int numRows = j-offset+1;
@@ -35,7 +34,6 @@ void ScaleTrapezoid( S alphaS, UpperOrLower uplo, Matrix<T>& A, Int offset )
     }
     else
     {
-        EL_PARALLEL_FOR
         for( Int j=0; j<width; ++j )
         {
             const Int numZeroRows = Max(j-offset,0);
@@ -62,7 +60,6 @@ ScaleTrapezoid
     {
         T* buffer = A.Buffer();
         const Int ldim = A.LDim();
-        EL_PARALLEL_FOR
         for( Int jLoc=0; jLoc<localWidth; ++jLoc )
         {
             const Int j = A.GlobalCol(jLoc);
@@ -78,7 +75,6 @@ ScaleTrapezoid
     {
         T* buffer = A.Buffer();
         const Int ldim = A.LDim();
-        EL_PARALLEL_FOR
         for( Int jLoc=0; jLoc<localWidth; ++jLoc )
         {
             const Int j = A.GlobalCol(jLoc);

--- a/include/El/blas_like/level1/Shift.hpp
+++ b/include/El/blas_like/level1/Shift.hpp
@@ -19,15 +19,27 @@ void Shift( Matrix<T>& A, S alpha )
     const Int width = A.Width();
     T* ABuf = A.Buffer();
     const Int ALDim = A.LDim();
-    EL_PARALLEL_FOR
-    for( Int j=0; j<width; ++j )
+
+    // Iterate over single loop if memory is contiguous. Otherwise
+    // iterate over double loop.
+    if( height == ALDim )
     {
-        EL_SIMD
-        for( Int i=0; i<height; ++i )
+        for( Int i=0; i<height*width; ++i )
         {
-            ABuf[i+j*ALDim] += alpha;
+            ABuf[i] += alpha;
         }
     }
+    else
+    {
+        for( Int j=0; j<width; ++j )
+        {
+            for( Int i=0; i<height; ++i )
+            {
+                ABuf[i+j*ALDim] += alpha;
+            }
+        }
+    }
+
 }
 
 template<typename T,typename S>

--- a/include/El/blas_like/level1/ShiftDiagonal.hpp
+++ b/include/El/blas_like/level1/ShiftDiagonal.hpp
@@ -17,11 +17,8 @@ void ShiftDiagonal( Matrix<T>& A, S alpha, Int offset )
     EL_DEBUG_CSE
     const Int height = A.Height();
     const Int width = A.Width();
-
     T* ABuf = A.Buffer();
     const Int ALDim = A.LDim();
-
-    EL_PARALLEL_FOR
     for( Int j=0; j<width; ++j )
     {
         const Int i = j-offset;
@@ -36,11 +33,8 @@ void ShiftDiagonal( AbstractDistMatrix<T>& A, S alpha, Int offset )
     EL_DEBUG_CSE
     const Int height = A.Height();
     const Int localWidth = A.LocalWidth();
-
     T* ABuf = A.Buffer();
     const Int ALDim = A.LDim();
-
-    EL_PARALLEL_FOR
     for( Int jLoc=0; jLoc<localWidth; ++jLoc )
     {
         const Int j = A.GlobalCol(jLoc);

--- a/include/El/blas_like/level1/Zero.hpp
+++ b/include/El/blas_like/level1/Zero.hpp
@@ -17,9 +17,24 @@ void Zero( Matrix<T>& A )
     EL_DEBUG_CSE
     const Int height = A.Height();
     const Int width = A.Width();
-    EL_PARALLEL_FOR
-    for( Int j=0; j<width; ++j )
-        MemZero( A.Buffer(0,j), height );
+    const Int ALDim = A.LDim();
+    T* ABuf = A.Buffer();
+
+    // Zero out all entries if memory is contiguous. Otherwise zero
+    // out each column.
+    if( ALDim == height )
+    {
+        MemZero( ABuf, height*width );
+    }
+    else
+    {
+        EL_PARALLEL_FOR
+        for( Int j=0; j<width; ++j )
+        {
+            MemZero( &ABuf[j*ALDim], height );
+        }
+    }
+
 }
 
 template<typename T>

--- a/tests/blas_like/Axpy.cpp
+++ b/tests/blas_like/Axpy.cpp
@@ -1,0 +1,137 @@
+/*
+   Copyright (c) 2009-2016, Jack Poulson
+   All rights reserved.
+
+   This file is part of Elemental and is under the BSD 2-Clause License,
+   which can be found in the LICENSE file in the root directory, or at
+   http://opensource.org/licenses/BSD-2-Clause
+*/
+#include <El.hpp>
+using namespace El;
+
+template<typename T>
+void TestAxpy
+( Int m,
+  Int n,
+  Int ldimX,
+  Int ldimY,
+  Int numThreads,
+  const Grid& g,
+  bool print )
+{
+    OutputFromRoot(g.Comm(),"Testing with ",TypeName<T>());
+    PushIndent();
+
+    double runTime, gflops;
+    Timer timer;
+
+#ifdef _OPENMP
+    if( numThreads > 0 )
+    {
+        omp_set_num_threads(numThreads);
+    }
+#endif
+
+    // Generate random matrices
+    DistMatrix<T> X(g), Y(g), YOrig(g), XData(g), YData(g);
+    DistMatrix<T,STAR,STAR> alpha(g);
+    Gaussian( alpha, 1, 1 );
+    Gaussian( XData, ldimX, n );
+    View( X, XData, IR(0,m), ALL );
+    Gaussian( YData, ldimY, n );
+    View( Y, YData, IR(0,m), ALL );
+    Zeros( YOrig, m, n );
+    Copy( Y, YOrig );
+    if( print )
+    {
+        Print( alpha, "alpha" );
+        Print( X, "X" );
+        Print( Y, "Y" );
+    }
+
+    // Clear L3 cache
+    Matrix<float> temp;
+    double cacheSize = 1e7;
+    temp.Resize( Int(cacheSize/sizeof(float)), 1 );
+    Scale( 2.f, temp );
+
+    // Apply axpy
+    if( g.Rank() == 0 )
+    {
+        Output("  Starting Axpy");
+    }
+    mpi::Barrier( g.Comm() );
+    timer.Start();
+    Axpy( alpha.Get(0,0), X, Y );
+    mpi::Barrier( g.Comm() );
+    runTime = timer.Stop();
+
+    // Print results
+    gflops = 2e-9 * m * n / runTime;
+    OutputFromRoot(g.Comm(),"Finished in ",runTime," seconds (",gflops," GFLOPS)");
+    if( print )
+    {
+        Print( Y, "Y" );
+    }
+
+    PopIndent();
+}
+
+int
+main( int argc, char* argv[] )
+{
+    Environment env( argc, argv );
+    mpi::Comm comm = mpi::COMM_WORLD;
+
+    try
+    {
+        // Get command-line arguments
+        int gridHeight = Input("--gridHeight","height of process grid",0);
+        const Int m = Input("--m","height of matrix",100);
+        const Int n = Input("--n","width of matrix",100);
+        Int ldimX = Input("--ldimX","leading dimension of matrix X",100);
+        Int ldimY = Input("--ldimY","leading dimension of matrix Y",100);
+        const Int numThreads = Input("--numThreads","number of OpenMP threads (-1=default)",-1);
+        const Int nb = Input("--nb","algorithmic blocksize",96);
+        const bool colMajor = Input("--colMajor","column-major ordering?",true);
+        const bool print = Input("--print","print matrices?",false);
+        ProcessInput();
+        PrintInputReport();
+
+        // Set Elemental parameters
+        if( gridHeight == 0 )
+            gridHeight = Grid::DefaultHeight( mpi::Size(comm) );
+        const GridOrder order = ( colMajor ? COLUMN_MAJOR : ROW_MAJOR );
+        const Grid g( comm, gridHeight, order );
+        SetBlocksize( nb );
+        ldimX = Max(m, ldimX);
+        ldimY = Max(m, ldimY);
+        ComplainIfDebug();
+
+        // Message
+        OutputFromRoot(comm,"Testing Axpy");
+
+        // Run tests
+        TestAxpy<float>( m, n, ldimX, ldimY, numThreads, g, print );
+        TestAxpy<Complex<float>>( m, n, ldimX, ldimY, numThreads, g, print );
+        TestAxpy<double>( m, n, ldimX, ldimY, numThreads, g, print );
+        TestAxpy<Complex<double>>( m, n, ldimX, ldimY, numThreads, g, print );
+#ifdef EL_HAVE_QD
+        TestAxpy<DoubleDouble>( m, n, ldimX, ldimY, numThreads, g, print );
+        TestAxpy<QuadDouble>( m, n, ldimX, ldimY, numThreads, g, print );
+        TestAxpy<Complex<DoubleDouble>>( m, n, ldimX, ldimY, numThreads, g, print );
+        TestAxpy<Complex<QuadDouble>>( m, n, ldimX, ldimY, numThreads, g, print );
+#endif
+#ifdef EL_HAVE_QUAD
+        TestAxpy<Quad>( m, n, ldimX, ldimY, numThreads, g, print );
+        TestAxpy<Complex<Quad>>( m, n, ldimX, ldimY, numThreads, g, print );      
+#endif
+#ifdef EL_HAVE_QUAD
+        TestAxpy<BigFloat>( m, n, ldimX, ldimY, numThreads, g, print );
+        TestAxpy<Complex<BigFloat>>( m, n, ldimX, ldimY, numThreads, g, print );
+#endif
+    }
+    catch( exception& e ) { ReportException(e); }
+
+    return 0;
+}


### PR DESCRIPTION
Resolves #225 by eliminating calls to external BLAS 1 routines. To facilitate compiler optimization, some routines iterate over a single loop rather than a double loop if the matrix data is contiguous. EntrywiseMap, IndexDependentFill, and IndexDependentMap now parallelize entry-wise (rather than column-wise) when applied to column vectors.