### PR TITLE
Optimizing BLAS 1-like routines

### DIFF
--- a/include/El/blas_like/level1/Axpy.hpp
+++ b/include/El/blas_like/level1/Axpy.hpp
@@ -39,10 +39,9 @@ void Axpy( S alphaS, const Matrix<T>& X, Matrix<T>& Y )
           if( XLength != YLength )
               LogicError("Nonconformal Axpy");
         )
+        EL_PARALLEL_FOR
         for( Int i=0; i<XLength; ++i )
-        {
             YBuf[i*YStride] += alpha*XBuf[i*XStride];
-        }
     }
     else
     {
@@ -50,15 +49,16 @@ void Axpy( S alphaS, const Matrix<T>& X, Matrix<T>& Y )
         // memory. Otherwise iterate over double loop.
         if( ldX == mX && ldY == mX )
         {
+            EL_PARALLEL_FOR
             for( Int i=0; i<mX*nX; ++i )
-            {
                 YBuf[i] += alpha*XBuf[i];
-            }
         }
         else
         {
+            EL_PARALLEL_FOR
             for( Int j=0; j<nX; ++j )
             {
+                EL_SIMD
                 for( Int i=0; i<mX; ++i )
                 {
                     YBuf[i+j*ldY] += alpha*XBuf[i+j*ldX];

--- a/include/El/blas_like/level1/Hadamard.hpp
+++ b/include/El/blas_like/level1/Hadamard.hpp
@@ -37,30 +37,29 @@ void Hadamard( const Matrix<T>& A, const Matrix<T>& B, Matrix<T>& C )
         // Check if output matrix is equal to either input matrix
         if( CBuf == BBuf )
         {
+            EL_PARALLEL_FOR
             for( Int i=0; i<height*width; ++i )
-            {
                 CBuf[i] *= ABuf[i];
-            }
         }
         else if( CBuf == ABuf )
         {
+            EL_PARALLEL_FOR
             for( Int i=0; i<height*width; ++i )
-            {
                 CBuf[i] *= BBuf[i];
-            }
         }
         else
         {
+            EL_PARALLEL_FOR
             for( Int i=0; i<height*width; ++i )
-            {
                 CBuf[i] = ABuf[i] * BBuf[i];
-            }
         }
     }
     else
     {
+        EL_PARALLEL_FOR
         for( Int j=0; j<width; ++j )
         {
+            EL_SIMD
             for( Int i=0; i<height; ++i )
             {
                 CBuf[i+j*CLDim] = ABuf[i+j*ALDim] * BBuf[i+j*BLDim];

--- a/include/El/blas_like/level1/Scale.hpp
+++ b/include/El/blas_like/level1/Scale.hpp
@@ -32,15 +32,16 @@ void Scale( S alphaS, Matrix<T>& A )
     {
         if( ALDim == height )
         {
+            EL_PARALLEL_FOR
             for( Int i=0; i<height*width; ++i )
-            {
                 ABuf[i] *= alpha;
-            }
         }
         else
         {
+            EL_PARALLEL_FOR
             for( Int j=0; j<width; ++j )
             {
+                EL_SIMD
                 for( Int i=0; i<height; ++i )
                 {
                     ABuf[i+j*ALDim] *= alpha;


### PR DESCRIPTION
I find that local matrix transposes take a non-trivial portion of the runtime of some variants of SUMMA GEMM (25%-50% on one process, 10% on four processes). A blocked algorithm drastically reduces time spent in these transposes.

I've also reenabled OpenMP in Axpy, Hadamard, and Scale. These were removed based on results in #225 that show that OpenMP does not make a significant improvement on 2D loops. However, tests by @ndryden on Hadamard show a 2x speedup using OpenMP on single loops.