### PR TITLE
correct a path in the ElementalConfig.cmake.in file

### DIFF
--- a/cmake/configure_files/ElementalConfig.cmake.in
+++ b/cmake/configure_files/ElementalConfig.cmake.in
@@ -13,6 +13,6 @@ set(Elemental_LINK_FLAGS "@EL_LINK_FLAGS@")
 set(Elemental_DEFINITIONS "@Qt5Widgets_DEFINITIONS@")
 
 # Our library dependencies (contains definitions for IMPORTED targets)
-include("@CMAKE_INSTALL_PREFIX@/CMake/elemental/ElementalTargets.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/ElementalTargets.cmake")
 
 set(Elemental_LIBRARIES El)

--- a/cmake/configure_files/ElementalConfig.cmake.in
+++ b/cmake/configure_files/ElementalConfig.cmake.in
@@ -13,6 +13,6 @@ set(Elemental_LINK_FLAGS "@EL_LINK_FLAGS@")
 set(Elemental_DEFINITIONS "@Qt5Widgets_DEFINITIONS@")
 
 # Our library dependencies (contains definitions for IMPORTED targets)
-include("@CMAKE_INSTALL_PREFIX@/CMake/ElementalTargets.cmake")
+include("@CMAKE_INSTALL_PREFIX@/CMake/elemental/ElementalTargets.cmake")
 
 set(Elemental_LIBRARIES El)


### PR DESCRIPTION
Both ElementalConfig.cmake and ElementalTargets.cmake are installed to ${INSTALL_CMAKE_DIR}/elemental. This is now reflected in the include() in the ElementalConfig.cmake.in file.

Also, these .cmake files will not work in the build directory. Unless someone has a more pressing need than I, I'll get to this in a later effort.
