### PR TITLE
Workaround for Intel compiler issue mentioned in #215

### DIFF
--- a/src/core/DistMatrix/Block/setup.hpp
+++ b/src/core/DistMatrix/Block/setup.hpp
@@ -163,8 +163,7 @@ DistMatrix<T,ROWDIST,COLDIST,BLOCK>* BDM::ConstructTranspose
 { return new DistMatrix<T,ROWDIST,COLDIST,BLOCK>(g,root); }
 
 template<typename T>
-DistMatrix<T,DiagCol<COLDIST,ROWDIST>(),
-             DiagRow<COLDIST,ROWDIST>(),BLOCK>*
+typename BDM::diagType*
 BDM::ConstructDiagonal
 ( const El::Grid& g, int root ) const
 { return new DistMatrix<T,DiagCol<COLDIST,ROWDIST>(),

--- a/src/core/DistMatrix/Element/setup.hpp
+++ b/src/core/DistMatrix/Element/setup.hpp
@@ -147,8 +147,7 @@ DistMatrix<T,ROWDIST,COLDIST>* DM::ConstructTranspose
 { return new DistMatrix<T,ROWDIST,COLDIST>(g,root); }
 
 template<typename T>
-DistMatrix<T,DiagCol<COLDIST,ROWDIST>(),
-             DiagRow<COLDIST,ROWDIST>()>*
+typename DM::diagType*
 DM::ConstructDiagonal
 ( const El::Grid& g, int root ) const
 { return new DistMatrix<T,DiagCol<COLDIST,ROWDIST>(),


### PR DESCRIPTION
Fixes #215 for Intel 17+. I tested with 16.0.3, 17.0.0, 17.0.2, and 18.0-beta, and life's (mostly) good. With 16.0.3 and 17.0.0, I ran into some other issues (see #177) so the compilation doesn't finish -- BUT! It gets past the matrix classes, which is the problem in #215 . 17.0.2 and 18.0-beta compiled just fine and the tests passed for me. Likewise, compiling with GCC 6.1.0 and 7.1.0 is still good.