### PR TITLE
Parallelizing copy and zero routines with OpenMP.

### DIFF
--- a/include/El/blas_like/level1/Zero.hpp
+++ b/include/El/blas_like/level1/Zero.hpp
@@ -20,11 +20,20 @@ void Zero( Matrix<T>& A )
     const Int ALDim = A.LDim();
     T* ABuf = A.Buffer();
 
-    // Zero out all entries if memory is contiguous. Otherwise zero
-    // out each column.
     if( ALDim == height )
     {
+#ifdef _OPENMP
+        // Manually set entries with OpenMP loop
+        // Note: We attempt to map entries of A to NUMA domains in a
+        // pattern convenient for future OpenMP loops.
+        EL_PARALLEL_FOR
+        for( Int i=0; i<height*width; ++i )
+        {
+            ABuf[i] = T(0);
+        }
+#else
         MemZero( ABuf, height*width );
+#endif
     }
     else
     {


### PR DESCRIPTION
I've found that we can accelerate the Copy and Zero routines by performing a manual loop with OpenMP parallelization rather than using std::memcpy or std::memset. This approach is also better for first-touch data allocation since memory will be allocated across the available NUMA domains rather than all on the first.

This change significantly improves the performance of certain Gemm configurations, although most stay roughly the same. For instance, here are the speedups I observe for the SUMMA_NN variants (matrices are square; 8 processes on 4 nodes; one 24-core Intel Xeon E5-2695 v2 per node; IB QDR interconnect):

![elemental_gemm](https://user-images.githubusercontent.com/4406448/33358517-f8cab44c-d47d-11e7-9e1c-d85650230625.png)

