### PR TITLE
Remove MPI runtime requirement for ParMETIS test 

### DIFF
--- a/cmake/modules/FindParMETIS.cmake
+++ b/cmake/modules/FindParMETIS.cmake
@@ -128,8 +128,8 @@ if(PARMETIS_INCLUDE_DIR AND METIS_INCLUDE_DIR AND
 int main( int argc, char* argv[] )
 {
   // FIXME: Find a simple but sensible test for ParMETIS
-  MPI_Init( &argc, &argv );
-  MPI_Finalize();
+  // MPI_Init( &argc, &argv );
+  // MPI_Finalize();
   return 0;
 }
 " PARMETIS_TEST_RUNS)


### PR DESCRIPTION
The test run of ParMETIS is done without the use of `MPIEXEC_EXECUTABLE` and this can lead to false negatives with some MPI implementations. This change further trivialises the test code to avoid this issue (and, given the `FIXME`, is equivalent).